### PR TITLE
change valuemap to a table and build via external scripts rather than in requests

### DIFF
--- a/ermrest/model.py
+++ b/ermrest/model.py
@@ -595,9 +595,11 @@ SELECT _ermrest.model_change_event();
         if empty or not vmap_parts:
             # create a dummy/empty view if no data sources exist (or empty table is requested)
             vmap_parts.append( "SELECT 's'::text, 't'::text, 'c'::text, 'v'::text WHERE False" )
+
+        if view_exists(cur, '_ermrest', 'valuemap'):
+            cur.execute("DROP MATERIALIZED VIEW IF EXISTS _ermrest.valuemap ;")
                         
         cur.execute("""
-DROP MATERIALIZED VIEW IF EXISTS _ermrest.valuemap ;
 DROP TABLE IF EXISTS _ermrest.valuemap ;
 CREATE TABLE _ermrest.valuemap ("schema", "table", "column", "value")
 AS %s ;

--- a/ermrest/model.py
+++ b/ermrest/model.py
@@ -480,14 +480,14 @@ FROM _ermrest.model_keyref_annotation
     model.ermrest_schema = model.schemas['_ermrest']
     del model.schemas['_ermrest']
     
-    if not view_exists(cur, '_ermrest', 'valuemap'):
-        # rebuild missing view and add it to model manually since we already introspected
-        web.debug('NOTICE: rebuilding valuemap during model introspection')
-        model.recreate_value_map(cur.connection, cur)
+    if not table_exists(cur, '_ermrest', 'valuemap'):
+        # rebuild missing table and add it to model manually since we already introspected
+        web.debug('NOTICE: adding empty valuemap during model introspection')
+        model.recreate_value_map(cur.connection, cur, empty=True)
         valuemap_columns = ['schema', 'table', 'column', 'value']
         for i in range(len(valuemap_columns)):
             valuemap_columns[i] = Column(valuemap_columns[i], i, Type(canonicalize_column_type('text', 'NULL', config, True)), None)
-        model.ermrest_schema.tables['valuemap'] = Table(model.ermrest_schema, 'valuemap', valuemap_columns, 'm')
+        model.ermrest_schema.tables['valuemap'] = Table(model.ermrest_schema, 'valuemap', valuemap_columns, 't')
 
     return model
 
@@ -578,13 +578,12 @@ SELECT _ermrest.model_change_event();
         if sname not in self.schemas:
             raise exception.ConflictModel('Requested schema %s does not exist.' % sname)
         cur.execute("""
-DROP MATERIALIZED VIEW IF EXISTS _ermrest.valuemap;
 DROP SCHEMA %s ;
 SELECT _ermrest.model_change_event();
 """ % sql_identifier(sname))
         del self.schemas[sname]
 
-    def recreate_value_map(self, conn, cur):
+    def recreate_value_map(self, conn, cur, empty=False):
         vmap_parts = []
         for schema in self.schemas.values():
             for table in schema.tables.values():
@@ -593,13 +592,14 @@ SELECT _ermrest.model_change_event();
                     if part:
                         vmap_parts.append(part)
 
-        if not vmap_parts:
-            # create a dummy/empty view if no data sources exist
+        if empty or not vmap_parts:
+            # create a dummy/empty view if no data sources exist (or empty table is requested)
             vmap_parts.append( "SELECT 's'::text, 't'::text, 'c'::text, 'v'::text WHERE False" )
                         
         cur.execute("""
 DROP MATERIALIZED VIEW IF EXISTS _ermrest.valuemap ;
-CREATE MATERIALIZED VIEW _ermrest.valuemap ("schema", "table", "column", "value")
+DROP TABLE IF EXISTS _ermrest.valuemap ;
+CREATE TABLE _ermrest.valuemap ("schema", "table", "column", "value")
 AS %s ;
 CREATE INDEX _ermrest_valuemap_cluster_idx ON _ermrest.valuemap ("schema", "table", "column");
 CREATE INDEX _ermrest_valuemap_value_idx ON _ermrest.valuemap USING gin ( "value" gin_trgm_ops );
@@ -639,7 +639,6 @@ class Schema (object):
         self.tables[tname].pre_delete(conn, cur)
         # we keep around a bumped version for table as a tombstone to invalidate any old cached results
         cur.execute("""
-DROP MATERIALIZED VIEW IF EXISTS _ermrest.valuemap;
 DROP TABLE %(sname)s.%(tname)s ;
 SELECT _ermrest.model_change_event();
 SELECT _ermrest.data_change_event(%(snamestr)s, %(tnamestr)s);
@@ -795,7 +794,6 @@ WHERE schema_name = %(sname)s
     def alter_table(self, conn, cur, alterclause):
         """Generic ALTER TABLE ... wrapper"""
         cur.execute("""
-DROP MATERIALIZED VIEW IF EXISTS _ermrest.valuemap;
 ALTER TABLE %(sname)s.%(tname)s  %(alter)s ;
 SELECT _ermrest.model_change_event();
 SELECT _ermrest.data_change_event(%(snamestr)s, %(tnamestr)s);

--- a/sbin/ermrest-valuemap-recreate
+++ b/sbin/ermrest-valuemap-recreate
@@ -1,0 +1,74 @@
+#!/usr/bin/python
+
+import sys
+import web
+import psycopg2
+
+import ermrest
+import ermrest.sanepg2
+import ermrest.ermrest_apis
+import ermrest.exception
+
+def recreate_valuemap(catalog, conn, cur):
+    cur.execute("SELECT count(*) = 0 FROM pg_catalog.pg_extension WHERE extname = 'pg_trgm';")
+    if cur.next()[0]:
+        raise ValueError('Please run "CREATE EXTENSION pg_trgm" on database "%s" as Postgres superuser.' % catalog._dbname)
+
+    model = catalog.get_model(cur, ermrest.ermrest_apis.global_env)
+    model.recreate_value_map(conn, cur)
+
+def usage():
+    sys.stderr.write("""
+usage: ermrest-valuemap-recreate <catalog>
+
+Run this utility under the deployed ERMrest daemon account to recreate
+inverted _ermrest.valuemap table supporting the /textfacet/ API.
+
+Required argument is the catalog number.
+
+Exit status:
+
+  0  success
+  1  command-line usage error
+  2  registry not configured
+  3  catalog not found
+  5  other runtime errors
+
+"""
+                     )
+
+def main(argv):
+    if len(argv) == 1:
+        try:
+            catalog_id = int(argv[0])
+        except ValueError:
+            sys.stderr.write("Invalid catalog ID '%s'.\n" % argv[0])
+            return 1
+
+    else:
+        sys.stderr.write("Catalog ID is sole argument.\n")
+        return 1
+
+    if not ermrest.registry:
+        sys.stderr.write("ERMrest catalog registry not configured.")
+        return 2
+
+    result = ermrest.registry.lookup(catalog_id)
+    if not result:
+        sys.stderr.write("Catalog '%d' not found in registry.\n" % catalog_id)
+        return 3
+    catalog_descriptor = result[0]['descriptor']
+
+    catalog = ermrest.Catalog(ermrest.catalog_factory, catalog_descriptor)
+    
+    try:
+        ermrest.sanepg2.pooled_perform(catalog.dsn, lambda conn, cur: recreate_valuemap(catalog, conn, cur), verbose=False).next()
+    except Exception, e:
+        sys.stderr.write(str(e)+ "\n")
+        return 5
+
+    return 0
+    
+
+if __name__ == '__main__':
+    sys.exit( main(sys.argv[1:]) )

--- a/sbin/ermrest-valuemap-work
+++ b/sbin/ermrest-valuemap-work
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# 
+# Copyright 2012-2015 University of Southern California
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# paths set for installation
+VARLIBDIR=/var/lib/ermrest
+LIBEXECDIR=/usr/libexec/ermrest
+SHAREDIR=/usr/share/ermrest
+SBINDIR=/usr/sbin
+
+# named parameters that can be set by caller or on command-line above to override defaults...
+
+DAEMONUSER="${DAEMONUSER:-ermrest}" # Unix and DB user name for service daemon
+
+# make these available to child processes
+export PGADMIN
+export DAEMONUSER
+
+# for all catalogs, do periodic maintenance of _ermrest.valuemap inverted table
+runuser -c "psql -q -t -A -c \"SELECT id FROM ermrest.simple_registry\" ermrest" - "${DAEMONUSER}" | {
+    while read cat_id
+    do
+	runuser -c "ermrest-valuemap-recreate ${cat_id}" - "${DAEMONUSER}"
+    done
+}
+

--- a/sbin/makefile-vars
+++ b/sbin/makefile-vars
@@ -7,6 +7,7 @@ SBIN_FILES= \
 	ermrest-registry-manage \
 	ermrest-freetext-indices \
 	ermrest-valuemap-recreate \
+	ermrest-valuemap-work \
 	ermrest-db-work
 
 SBIN_EDIT_FILES= \

--- a/sbin/makefile-vars
+++ b/sbin/makefile-vars
@@ -6,6 +6,7 @@ SBIN_FILES= \
 	ermrest-registry-deploy \
 	ermrest-registry-manage \
 	ermrest-freetext-indices \
+	ermrest-valuemap-recreate \
 	ermrest-db-work
 
 SBIN_EDIT_FILES= \


### PR DESCRIPTION
This PR addresses both #5 and #6 but does not automatically enable cron work.

On first request after update, the normal introspection will drop the existing valuemap materialized view and then create an *empty* valuemap table.  This should happen very quickly.

The external script `ermrest-valuemap-recreate` should be called with a catalog ID number or the script `ermrest-valuemap-work` to automatically rebuild on all existing catalogs in the registry. The latter script is appropriate as a cron job.