### PR TITLE
Fixes to error reporting and db pool finalization

### DIFF
--- a/ermrest/apicore.py
+++ b/ermrest/apicore.py
@@ -165,6 +165,15 @@ def request_final():
             range = web.ctx.ermrest_request_content_range,
             type = web.ctx.ermrest_content_type
             ))
+    if web.ctx.ermrest_catalog_pc is not None:
+        if web.ctx.ermrest_catalog_pc.conn is not None:
+            web.debug(
+                'ERMrest DB conn LEAK averted in request_final()!?',
+                web.ctx.env['REQUEST_METHOD'],
+                web.ctx.env['REQUEST_URI'],
+                web.ctx.status
+            )
+            web.ctx.ermrest_catalog_pc.final()
     logger.info( (log_final_template % parts).encode('utf-8') )
 
 def web_method():

--- a/ermrest/ermrest_apis.py
+++ b/ermrest/ermrest_apis.py
@@ -141,6 +141,10 @@ class Dispatcher (object):
         finally:
             if ast is not None:
                 ast.final()
+            elif web.ctx.ermrest_catalog_pc is not None:
+                # this can happen if we start to instantiate a url.ast.catalog.Catalog
+                # and either fail with permission errors or have some other URL parse error!
+                web.ctx.ermrest_catalog_pc.final()
 
     def HEAD(self):
         return self.METHOD('HEAD')

--- a/ermrest/ermrest_apis.py
+++ b/ermrest/ermrest_apis.py
@@ -113,6 +113,8 @@ class Dispatcher (object):
             return uri, url_parse_func(uri)
         except (LexicalError, ParseError), te:
             raise rest.BadRequest(str(te))
+        except rest.WebException, te:
+            raise te
         except:
             et, ev, tb = sys.exc_info()
             web.debug('got exception "%s" during URI parse' % str(ev),

--- a/test/rest-tests.sh
+++ b/test/rest-tests.sh
@@ -158,6 +158,7 @@ echo "Using catalog \"${cid}\" for testing." >&2
 ###### do tests on catalog
 
 dotest "200::application/json::*" /catalog/${cid}/schema
+dotest "400::*::*" /catalog/${cid}/invalid_api_name
 dotest "409::*::*" /catalog/${cid}/schema/public -X POST
 dotest "201::*::*" /catalog/${cid}/schema/test1 -X POST
 dotest "200::application/json::*" /catalog/${cid}/schema


### PR DESCRIPTION
1. Suppress diagnostics for an exception path during URI parse that is now possible with earlier binding of the catalog connection.
1. Add a catch-all to clean up and log diagnostics if we still seem to leak database connections at the end of request handling.
1. Add a test case that reported leaking connections due to failing somewhere between creating a catalog and returning a full URI parse tree.
1. Add a fix to avoid leaking via this error path, to document it and silence the catch-all diagnostics which remain in case there are further flaws not triggered by the current test suite.