### PR TITLE
View constraints

### DIFF
--- a/api-doc/model/naming.md
+++ b/api-doc/model/naming.md
@@ -128,6 +128,11 @@ Each (composite) key constraint is reified as a model-level resource:
 
 This named constraint has a representation which summarizes its set of constituent key columns. The meaning of a key constraint is that the combination of listed columns must be a unique identifier for rows in the table, i.e. no two rows can share the same combination of values for those columns.
 
+ERMrest also supports pseudo-keys on views, which allow the uniqueness properties of views to be asserted both for clients introspecting the catalog model and for ERMrest itself to reason about queries on the view. Psuedo-keys are chosen automatically when an authorized client creates a key constraint on a view, while real database constraints are used when the client creates a key constraint on a table.
+
+  - *NOTE* pseudo-keys are advisory, *not enforced* in the database, and *not validated* by ERMrest. A client SHOULD NOT assert inaccurate psuedo-key constraints as it could mislead other clients who introspect the schema or lead to unexpected query results as ERMrest formulates relational queries assuming the constraints are true.
+  - Future ERMrest releases MAY enforce validation on psuedo-keys so clients SHOULD NOT depend on the ability to create inaccurate psuedo-constraints.
+
 Additionally, a composite resource summarizes all existing key constraints on one table for convenient discovery and bulk retrieval:
 
 - _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_ `/key`
@@ -161,6 +166,11 @@ Each (composite) foreign key constraint is reified as a model-level resource:
 - _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_ `/foreignkey/` _column name_ `,` ... `/reference/` _table reference_ `/` _key column_ `,` ...
 
 This named constraint has a representation which summarizes its set of constituent foreign key columns, another referenced table, and the set of key columns that form the composite key being referenced in that other table, including the mapping of each foreign key _column name_ to each composite key _key column_. The _table reference_ can be a qualified table name, e.g. `schema1:table1` or an unqualified table name, e.g. `table1`.  The meaning of this constraint is that each combination of non-NULL values in _schema name_:_table name_ MUST reference an existing combination of values forming a composite key for a row in _table reference_.
+
+ERMrest also supports pseudo-foreign keys on views, which allow the reference links of views to be asserted both for clients introspecting the catalog model and for ERMrest itself to reason about queries on the view. Psuedo-foreign keys are chosen automatically when an authorized client creates a foreign key constraint on a view or referencing a view, while real database constraints are used when the client creates a foreign key constraint on a table referencing another table.
+
+  - *NOTE* pseudo-foreign keys are advisory, *not enforced* in the database, and *not validated* by ERMrest. A client SHOULD NOT assert inaccurate psuedo-foreign key constraints as it could mislead other clients who introspect the schema or lead to unexpected query results as ERMrest formulates relational queries assuming the constraints are true.
+  - Future ERMrest releases MAY enforce validation on psuedo-foreign keys so clients SHOULD NOT depend on the ability to create inaccurate psuedo-constraints.
 
 Additionally, a composite resource summarizes all foreign key constraints on one table for discovery and bulk retrieval purposes:
 

--- a/api-doc/model/rest.md
+++ b/api-doc/model/rest.md
@@ -619,6 +619,7 @@ The DELETE method is used to remove a foreign key constraint from a table using 
 - _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_ `/foreignkey/` _column name_ `,` ... `/reference/` _table reference_ `/` _key column_ `,` ...
 
 These names differ in how many constraints are applied to filter the set of retrieved foreign key references:
+
 1. The list is always constrained to foreign keys stored in _schema name_ : _table name_
 1. The list MAY be constrained by the composite foreign key _column name_ list of its constituent keys, interpreted as a set of columns
 1. The list MAY be constrained by the _table reference_ of the table containing the composite key or keys referenced by the composite foreign key

--- a/api-doc/model/rest.md
+++ b/api-doc/model/rest.md
@@ -394,12 +394,12 @@ Typical error response codes include:
 
 ## Key Creation
 
-The POST operation is used to add a key constraint to an existing table's key list resource:
+The POST operation is used to add a key constraint to an existing table's key list resource, or a pseudo-key constraint to a view's key list resource:
 
 - _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_ `/key`
 - _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_ `/key/`
 
-In this operation, the `application/json` _key representation_ is supplied as input:
+In this operation, the _table name_ MAY be an existing table or view in the named schema, and the `application/json` _key representation_ is supplied as input:
 
     POST /ermrest/catalog/42/schema/schema_name/table/table_name/key HTTP/1.1
 	Host: www.example.com
@@ -463,7 +463,7 @@ Typical error response codes include:
 
 ## Key Deletion
 
-The DELETE method is used to remove a key constraint from a table:
+The DELETE method is used to remove a key constraint from a table or a pseudo-key constraint from a view:
 
     DELETE /ermrest/catalog/42/schema/schema_name/table/table_name/key/column_name,... HTTP/1.1
     Host: www.example.com
@@ -518,7 +518,7 @@ Typical error response codes include:
 
 ## Foreign Key Creation
 
-The POST operation is used to add a foreign key reference constraint to an existing table's foreign key list resource:
+The POST operation is used to add a foreign key reference constraint or pseudo-constraint to an existing table's or view's foreign key list resource:
 
 - _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_ `/foreignkey`
 - _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_ `/foreignkey/`
@@ -563,7 +563,7 @@ The input _foreign key reference representation_ is a long JSON document too ver
 - `comment`: whose value is the human-readable comment string for the foreign key reference constraint
 - `annotations`: whose value is a sub-object used as a dictionary where each field field of the sub-object is an _annotation key_ and its corresponding value a nested object structure representing the _annotation document_ content (as hierarchical content, not as a double-serialized JSON string!)
 
-The two arrays MUST have the same length and the order is important in that the two composite keys are mapped to one another element-by-element, so the first column of the composite foreign key refers to the first column of the composite referenced key, etc. In the `referenced_columns` list, the _schema name_ and _table name_ values MUST be identical for all referenced columns.
+The two arrays MUST have the same length and the order is important in that the two composite keys are mapped to one another element-by-element, so the first column of the composite foreign key refers to the first column of the composite referenced key, etc. In the `referenced_columns` list, the _schema name_ and _table name_ values MUST be identical for all referenced columns. If both referencing and referenced _table name_ refer to tables, a real constraint is created; if either referencing or referenced _table name_ refer to a view, a pseudo-constraint is created instead.
 
 On success, the response is:
 

--- a/ermrest/catalog.py
+++ b/ermrest/catalog.py
@@ -305,6 +305,33 @@ CREATE TABLE %(schema)s.%(table)s (
         # create annotation storage tables
         for klass in annotatable_classes:
             klass.create_storage_table(cur)
+
+        if not table_exists(cur, self._SCHEMA_NAME, 'model_pseudo_key'):
+            cur.execute("""
+CREATE TABLE _ermrest.model_pseudo_key (
+  id serial PRIMARY KEY,
+  schema_name text NOT NULL,
+  table_name text NOT NULL,
+  column_names text[] NOT NULL,
+  comment text,
+  UNIQUE(schema_name, table_name, column_names)
+);
+""")
+            
+        if not table_exists(cur, self._SCHEMA_NAME, 'model_pseudo_keyref'):
+            cur.execute("""
+CREATE TABLE _ermrest.model_pseudo_keyref (
+  id serial PRIMARY KEY,
+  from_schema_name text NOT NULL,
+  from_table_name text NOT NULL,
+  from_column_names text[] NOT NULL,
+  to_schema_name text NOT NULL,
+  to_table_name text NOT NULL,
+  to_column_names text[] NOT NULL,
+  comment text,
+  UNIQUE(from_schema_name, from_table_name, from_column_names, to_schema_name, to_table_name, to_column_names)
+);
+""")
             
         if not table_exists(cur, self._SCHEMA_NAME, self._MODEL_VERSION_TABLE_NAME):
             cur.execute("""

--- a/ermrest/model/introspect.py
+++ b/ermrest/model/introspect.py
@@ -320,7 +320,7 @@ FROM _ermrest.model_pseudo_keyref ;
     for pk_id, pk_table_schema, pk_table_name, pk_column_names, pk_comment in cur:
         _introspect_pkey(
             pk_table_schema, pk_table_name, pk_column_names, pk_comment,
-            lambda pk_colset: Unique(pk_colset, (pk_schema, pk_name), pk_comment)
+            lambda pk_colset: PseudoUnique(pk_colset, pk_id, pk_comment)
         )
             
     #

--- a/ermrest/model/introspect.py
+++ b/ermrest/model/introspect.py
@@ -294,8 +294,11 @@ FROM _ermrest.model_pseudo_keyref ;
     # Introspect uniques / primary key references, aggregated by constraint
     #
     def _introspect_pkey(pk_table_schema, pk_table_name, pk_column_names, pk_comment, pk_factory):
-        pk_cols = [ columns[(dname, pk_table_schema, pk_table_name, pk_column_name)]
-                    for pk_column_name in pk_column_names ]
+        try:
+            pk_cols = [ columns[(dname, pk_table_schema, pk_table_name, pk_column_name)]
+                        for pk_column_name in pk_column_names ]
+        except KeyError:
+            return
 
         pk_colset = frozenset(pk_cols)
 
@@ -331,10 +334,13 @@ FROM _ermrest.model_pseudo_keyref ;
             uq_table_schema, uq_table_name, uq_column_names, fk_comment,
             fkr_factory
     ):
-        fk_cols = [ columns[(dname, fk_table_schema, fk_table_name, fk_column_names[i])]
-                    for i in range(0, len(fk_column_names)) ]
-        pk_cols = [ columns[(dname, uq_table_schema, uq_table_name, uq_column_names[i])]
-                    for i in range(0, len(uq_column_names)) ]
+        try:
+            fk_cols = [ columns[(dname, fk_table_schema, fk_table_name, fk_column_names[i])]
+                        for i in range(0, len(fk_column_names)) ]
+            pk_cols = [ columns[(dname, uq_table_schema, uq_table_name, uq_column_names[i])]
+                        for i in range(0, len(uq_column_names)) ]
+        except KeyError:
+            return
 
         fk_colset = frozenset(fk_cols)
         pk_colset = frozenset(pk_cols)

--- a/ermrest/model/misc.py
+++ b/ermrest/model/misc.py
@@ -323,17 +323,6 @@ class Schema (object):
         """Drop a table from the schema."""
         if tname not in self.tables:
             raise exception.ConflictModel('Requested table %s does not exist in schema %s.' % (tname, self.name))
-        self.tables[tname].pre_delete(conn, cur)
-        # we keep around a bumped version for table as a tombstone to invalidate any old cached results
-        cur.execute("""
-DROP TABLE %(sname)s.%(tname)s ;
-SELECT _ermrest.model_change_event();
-SELECT _ermrest.data_change_event(%(snamestr)s, %(tnamestr)s);
-""" % dict(sname=sql_identifier(self.name), 
-           tname=sql_identifier(tname),
-           snamestr=sql_literal(self.name), 
-           tnamestr=sql_literal(tname)
-           )
-                    )
+        self.tables[tname].delete(conn, cur)
         del self.tables[tname]
 

--- a/ermrest/model/misc.py
+++ b/ermrest/model/misc.py
@@ -140,6 +140,8 @@ DELETE FROM _ermrest.model_%s_annotation WHERE %s;
 
     @classmethod
     def create_storage_table(orig_class, cur):
+        if table_exists(cur, '_ermrest', 'model_%s_annotation' % restype):
+            return
         keys = keying.keys() + ['annotation_uri']
         cur.execute("""
 CREATE TABLE _ermrest.model_%s_annotation (%s);
@@ -179,7 +181,8 @@ SELECT %s FROM _ermrest.model_%s_annotation;
         setattr(orig_class, 'set_annotation', set_annotation)
         setattr(orig_class, 'delete_annotation', delete_annotation)
         setattr(orig_class, '_annotation_keying', keying)
-        setattr(orig_class, 'introspect_helper', introspect_helper)
+        if hasattr(orig_class, 'introspect_annotation'):
+            setattr(orig_class, 'introspect_helper', introspect_helper)
         setattr(orig_class, 'create_storage_table', create_storage_table)
         annotatable_classes.append(orig_class)
         return orig_class

--- a/ermrest/model/table.py
+++ b/ermrest/model/table.py
@@ -229,15 +229,6 @@ SELECT _ermrest.data_change_event(%(snamestr)s, %(tnamestr)s);
             self.alter_table(conn, cur, 'ADD %s' % key.sql_def())
             yield key
 
-    def delete_unique(self, conn, cur, unique):
-        """Delete unique constraint(s) from table."""
-        if unique.columns not in self.uniques or len(unique.constraint_names) == 0:
-            raise exception.ConflictModel('Unique constraint columns %s not understood in table %s:%s.' % (unique.columns, self.schema.name, self.name))
-        unique.pre_delete(conn, cur)
-        for pk_schema, pk_name in unique.constraint_names:
-            # TODO: can constraint ever be in a different postgres schema?  if so, how do you drop it?
-            self.alter_table(conn, cur, 'DROP CONSTRAINT %s' % sql_identifier(pk_name))
-
     def add_fkeyref(self, conn, cur, fkrdoc):
         """Add foreign-key reference constraint to table."""
         for fkr in KeyReference.fromjson(self.schema.model, fkrdoc, None, self, None, None, None):
@@ -246,14 +237,6 @@ SELECT _ermrest.data_change_event(%(snamestr)s, %(tnamestr)s);
             for k, v in fkr.annotations.items():
                 fkr.set_annotation(conn, cur, k, v)
             yield fkr
-
-    def delete_fkeyref(self, conn, cur, fkr):
-        """Delete foreign-key reference constraint(s) from table."""
-        assert fkr.foreign_key.table == self
-        fkr.pre_delete(conn, cur)
-        for fk_schema, fk_name in fkr.constraint_names:
-            # TODO: can constraint ever be in a different postgres schema?  if so, how do you drop it?
-            self.alter_table(conn, cur, 'DROP CONSTRAINT %s' % sql_identifier(fk_name))
 
     def prejson(self):
         return dict(

--- a/ermrest/model/table.py
+++ b/ermrest/model/table.py
@@ -115,7 +115,7 @@ class Table (object):
         annotations = tabledoc.get('annotations', {})
         columns = Column.fromjson(tabledoc.get('column_definitions',[]), ermrest_config)
         comment = tabledoc.get('comment')
-        table = Table(schema, tname, columns, kind, comment, annotations)
+        table = Table(schema, tname, columns, 'r', comment, annotations)
         keys = Unique.fromjson(table, tabledoc.get('keys', []))
         fkeys = ForeignKey.fromjson(table, tabledoc.get('foreign_keys', []))
 

--- a/ermrest/url/ast/model.py
+++ b/ermrest/url/ast/model.py
@@ -479,7 +479,7 @@ class Key (Api):
 
     def DELETE_body(self, conn, cur):
         key = self.GET_body(conn, cur)
-        key.table.delete_unique(conn, cur, key)
+        key.delete(conn, cur)
         return ''
 
     def DELETE(self, uri):
@@ -656,7 +656,7 @@ class ForeignkeyReferences (Api):
     def DELETE_body(self, conn, cur):
         fkrs = self.GET_body(conn, cur)
         for fkr in fkrs:
-            fkr.foreign_key.table.delete_fkeyref(conn, cur, fkr)
+            fkr.delete(conn, cur)
         return ''
 
     def DELETE(self, uri):

--- a/ermrest/url/ast/model.py
+++ b/ermrest/url/ast/model.py
@@ -505,7 +505,7 @@ class Foreignkeys (Api):
         def post_commit(self, newrefs):
             web.ctx.status = '201 Created'
             return json.dumps([ r.prejson() for r in newrefs ], indent=2) + '\n'
-        return _MODIFY(self, self.POST_body, _post_commit_json)
+        return _MODIFY_with_json_input(self, self.POST_body, post_commit)
 
 class Foreignkey (Api):
     """A specific foreign key by column set."""

--- a/sbin/ermrest-db-work
+++ b/sbin/ermrest-db-work
@@ -148,15 +148,18 @@ WHERE NOT p.column_names <@ (
 DELETE FROM _ermrest.model_key_annotation a
 WHERE NOT a.column_names IN (
   SELECT
-    COALESCE(array_agg(pka.attname::text ORDER BY pka.attname), ARRAY[]::text[]) AS pk_column_names
+    (SELECT array_agg(ka.attname::text ORDER BY ka.attname::text)
+     FROM generate_subscripts(con.conkey, 1) i
+     JOIN pg_catalog.pg_attribute ka ON con.conrelid = ka.attrelid AND con.conkey[i.i] = ka.attnum
+    ) AS uq_column_names
   FROM pg_namespace ncon
   JOIN pg_constraint con ON ncon.oid = con.connamespace
-  JOIN pg_class pkcl ON con.conrelid = pkcl.oid AND con.contype = ANY (ARRAY['u'::"char",'p'::"char"])
-  JOIN pg_namespace npk ON pkcl.relnamespace = npk.oid
-  JOIN pg_catalog.pg_attribute pka ON con.conrelid = pka.attrelid
-  WHERE pg_has_role(pkcl.relowner, 'USAGE'::text)
-    AND a.schema_name = npk.nspname::text
-    AND a.table_name = pkcl.relname::text
+  JOIN pg_class kcl ON con.conrelid = kcl.oid AND con.contype = ANY (ARRAY['u'::"char", 'p'::"char"])
+  JOIN pg_namespace nk ON kcl.relnamespace = nk.oid
+  WHERE (pg_has_role(kcl.relowner, 'USAGE'::text) 
+         OR has_table_privilege(kcl.oid, 'INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'::text) OR has_any_column_privilege(kcl.oid, 'INSERT, UPDATE, REFERENCES'::text))
+    AND a.schema_name = ncon.nspname::text
+    AND a.table_name = kcl.relname::text
   UNION
   SELECT column_names AS pk_column_names 
   FROM _ermrest.model_pseudo_key p
@@ -189,15 +192,18 @@ WHERE NOT p.from_column_names <@ (
   )
    OR NOT p.to_column_names IN (
   SELECT
-    COALESCE(array_agg(pka.attname::text ORDER BY pka.attname), ARRAY[]::text[]) AS pk_column_names
+    (SELECT array_agg(ka.attname::text ORDER BY ka.attname::text)
+     FROM generate_subscripts(con.conkey, 1) i
+     JOIN pg_catalog.pg_attribute ka ON con.conrelid = ka.attrelid AND con.conkey[i.i] = ka.attnum
+    ) AS uq_column_names
   FROM pg_namespace ncon
   JOIN pg_constraint con ON ncon.oid = con.connamespace
-  JOIN pg_class pkcl ON con.conrelid = pkcl.oid AND con.contype = ANY (ARRAY['u'::"char",'p'::"char"])
-  JOIN pg_namespace npk ON pkcl.relnamespace = npk.oid
-  JOIN pg_catalog.pg_attribute pka ON con.conrelid = pka.attrelid
-  WHERE pg_has_role(pkcl.relowner, 'USAGE'::text)
-    AND p.to_schema_name = npk.nspname::text
-    AND p.to_table_name = pkcl.relname::text
+  JOIN pg_class kcl ON con.conrelid = kcl.oid AND con.contype = ANY (ARRAY['u'::"char", 'p'::"char"])
+  JOIN pg_namespace nk ON kcl.relnamespace = nk.oid
+  WHERE (pg_has_role(kcl.relowner, 'USAGE'::text) 
+         OR has_table_privilege(kcl.oid, 'INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'::text) OR has_any_column_privilege(kcl.oid, 'INSERT, UPDATE, REFERENCES'::text))
+    AND p.to_schema_name = ncon.nspname::text
+    AND p.to_table_name = kcl.relname::text
   UNION
   SELECT column_names AS pk_column_names 
   FROM _ermrest.model_pseudo_key p2

--- a/sbin/ermrest-db-work
+++ b/sbin/ermrest-db-work
@@ -144,6 +144,24 @@ WHERE NOT p.column_names <@ (
   )
 ;
 
+-- purge orphaned key annotations
+DELETE FROM _ermrest.model_key_annotation a
+WHERE NOT a.column_names IN (
+  SELECT
+    COALESCE(array_agg(pka.attname::text ORDER BY pka.attname), ARRAY[]::text[]) AS pk_column_names
+  FROM pg_namespace ncon
+  JOIN pg_constraint con ON ncon.oid = con.connamespace
+  JOIN pg_class pkcl ON con.conrelid = pkcl.oid AND con.contype = ANY (ARRAY['u'::"char",'p'::"char"])
+  JOIN pg_namespace npk ON pkcl.relnamespace = npk.oid
+  JOIN pg_catalog.pg_attribute pka ON con.conrelid = pka.attrelid
+  WHERE pg_has_role(pkcl.relowner, 'USAGE'::text)
+    AND a.schema_name = npk.nspname::text
+    AND a.table_name = pkcl.relname::text
+  UNION
+  SELECT column_names AS pk_column_names FROM _ermrest.model_pseudo_key
+  )
+;
+
 -- purge orphaned keyref annotations
 DELETE FROM _ermrest.model_keyref_annotation a
 USING (

--- a/sbin/ermrest-db-work
+++ b/sbin/ermrest-db-work
@@ -158,7 +158,10 @@ WHERE NOT a.column_names IN (
     AND a.schema_name = npk.nspname::text
     AND a.table_name = pkcl.relname::text
   UNION
-  SELECT column_names AS pk_column_names FROM _ermrest.model_pseudo_key
+  SELECT column_names AS pk_column_names 
+  FROM _ermrest.model_pseudo_key p
+  WHERE a.schema_name = p.schema_name
+    AND a.table_name = p.table_name
   )
 ;
 

--- a/sbin/ermrest-db-work
+++ b/sbin/ermrest-db-work
@@ -170,7 +170,6 @@ WHERE NOT a.column_names IN (
 
 -- purge orphaned pseudo keyref constraints
 DELETE FROM _ermrest.model_pseudo_keyref p
-SELECT * FROM _ermrest.model_pseudo_keyref p
 WHERE NOT p.from_column_names <@ (
   SELECT COALESCE(array_agg(a.attname::text), ARRAY[]::text[]) AS column_names
   FROM pg_catalog.pg_attribute a

--- a/sbin/ermrest-db-work
+++ b/sbin/ermrest-db-work
@@ -165,6 +165,47 @@ WHERE NOT a.column_names IN (
   )
 ;
 
+-- purge orphaned pseudo keyref constraints
+DELETE FROM _ermrest.model_pseudo_keyref p
+SELECT * FROM _ermrest.model_pseudo_keyref p
+WHERE NOT p.from_column_names <@ (
+  SELECT COALESCE(array_agg(a.attname::text), ARRAY[]::text[]) AS column_names
+  FROM pg_catalog.pg_attribute a
+  JOIN pg_catalog.pg_class c ON (a.attrelid = c.oid)
+  JOIN pg_catalog.pg_namespace nc ON (c.relnamespace = nc.oid)
+  LEFT JOIN pg_catalog.pg_attrdef ad ON (a.attrelid = ad.adrelid AND a.attnum = ad.adnum)
+  JOIN pg_catalog.pg_type t ON (t.oid = a.atttypid)
+  JOIN pg_catalog.pg_namespace nt ON (t.typnamespace = nt.oid)
+  LEFT JOIN pg_catalog.pg_type bt ON (t.typtype = 'd'::"char" AND t.typbasetype = bt.oid)
+  LEFT JOIN pg_catalog.pg_namespace nbt ON (bt.typnamespace = nbt.oid)
+  WHERE nc.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+    AND NOT pg_is_other_temp_schema(nc.oid) 
+    AND a.attnum > 0
+    AND NOT a.attisdropped
+    AND (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char"])) 
+    AND (pg_has_role(c.relowner, 'USAGE'::text) OR has_column_privilege(c.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'::text))
+    AND p.from_schema_name = nc.nspname
+    AND p.from_table_name = c.relname
+  )
+   OR NOT p.to_column_names IN (
+  SELECT
+    COALESCE(array_agg(pka.attname::text ORDER BY pka.attname), ARRAY[]::text[]) AS pk_column_names
+  FROM pg_namespace ncon
+  JOIN pg_constraint con ON ncon.oid = con.connamespace
+  JOIN pg_class pkcl ON con.conrelid = pkcl.oid AND con.contype = ANY (ARRAY['u'::"char",'p'::"char"])
+  JOIN pg_namespace npk ON pkcl.relnamespace = npk.oid
+  JOIN pg_catalog.pg_attribute pka ON con.conrelid = pka.attrelid
+  WHERE pg_has_role(pkcl.relowner, 'USAGE'::text)
+    AND p.to_schema_name = npk.nspname::text
+    AND p.to_table_name = pkcl.relname::text
+  UNION
+  SELECT column_names AS pk_column_names 
+  FROM _ermrest.model_pseudo_key p2
+  WHERE p.to_schema_name = p2.schema_name
+    AND p.to_table_name = p2.table_name
+  )
+;
+
 -- purge orphaned keyref annotations
 DELETE FROM _ermrest.model_keyref_annotation a
 USING (

--- a/sbin/ermrest-db-work
+++ b/sbin/ermrest-db-work
@@ -121,6 +121,29 @@ WHERE a.schema_name = a2.schema_name
   AND a.column_name = a2.column_name
 ;
 
+-- purge orphaned pseudo key constraints
+DELETE FROM _ermrest.model_pseudo_key p
+WHERE NOT p.column_names <@ (
+  SELECT COALESCE(array_agg(a.attname::text), ARRAY[]::text[]) AS column_names
+  FROM pg_catalog.pg_attribute a
+  JOIN pg_catalog.pg_class c ON (a.attrelid = c.oid)
+  JOIN pg_catalog.pg_namespace nc ON (c.relnamespace = nc.oid)
+  LEFT JOIN pg_catalog.pg_attrdef ad ON (a.attrelid = ad.adrelid AND a.attnum = ad.adnum)
+  JOIN pg_catalog.pg_type t ON (t.oid = a.atttypid)
+  JOIN pg_catalog.pg_namespace nt ON (t.typnamespace = nt.oid)
+  LEFT JOIN pg_catalog.pg_type bt ON (t.typtype = 'd'::"char" AND t.typbasetype = bt.oid)
+  LEFT JOIN pg_catalog.pg_namespace nbt ON (bt.typnamespace = nbt.oid)
+  WHERE nc.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+    AND NOT pg_is_other_temp_schema(nc.oid) 
+    AND a.attnum > 0
+    AND NOT a.attisdropped
+    AND (c.relkind = ANY (ARRAY['r'::"char", 'v'::"char", 'f'::"char"])) 
+    AND (pg_has_role(c.relowner, 'USAGE'::text) OR has_column_privilege(c.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'::text))
+    AND p.schema_name = nc.nspname
+    AND p.table_name = c.relname
+  )
+;
+
 -- purge orphaned keyref annotations
 DELETE FROM _ermrest.model_keyref_annotation a
 USING (

--- a/sbin/ermrest-db-work
+++ b/sbin/ermrest-db-work
@@ -151,6 +151,15 @@ LEFT OUTER JOIN (
          OR has_table_privilege(kcl.oid, 'INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'::text) OR has_any_column_privilege(kcl.oid, 'INSERT, UPDATE, REFERENCES'::text))
     AND (pg_has_role(fkcl.relowner, 'USAGE'::text) 
          OR has_table_privilege(fkcl.oid, 'INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'::text) OR has_any_column_privilege(fkcl.oid, 'INSERT, UPDATE, REFERENCES'::text))
+  UNION
+  SELECT
+    from_schema_name AS fk_table_schema,
+    from_table_name AS fk_table_name,
+    from_column_names AS fk_column_names,
+    to_schema_name AS uq_table_schema,
+    to_table_name AS uq_table_name,
+    to_column_names AS uq_column_names
+  FROM _ermrest.model_pseudo_keyref
 ) r ON (a.from_schema_name = r.fk_table_schema AND a.from_table_name = r.fk_table_name AND a.from_column_names = r.fk_column_names
         AND a.to_schema_name = r.uq_table_schema AND a.to_table_name = r.uq_table_Name AND a.to_column_names = r.uq_column_names)
 WHERE r.uq_column_names IS NULL


### PR DESCRIPTION
This adds schema-overlay storage for *unenforced* pseudo constraints to make ERMrest pretend that there are uniqueness or foreign key reference constraints not actually present in the database. The REST API uses this to enable constraint management on views. Previously, trying to add a constraint to a view would fail since the DB does not support it.  Currently, real constraints are managed on tables and pseudo constraints are managed on views. The introspection layer would actually allow pseudo constraints on tables as well, but the schema management API does not provide a way to create these.

This update breaks backward-compatibility with existing catalogs. The server schema introspection will fail at startup when accessing existing catalogs created by the older codebase. They need their `_ermrest` schema updated with two empty tables as per [the pseudo-constraint storage DDL in catalog.py](https://github.com/informatics-isi-edu/ermrest/blob/53744519f510d309e3f877784a1830f2d5084f46/ermrest/catalog.py#L309-L334).