### PR TITLE
Paging modifers

### DIFF
--- a/ermrest/ermpath/resource.py
+++ b/ermrest/ermpath/resource.py
@@ -1167,11 +1167,6 @@ class AttributePath (AnyPath):
         outputs = set()
         output_types = {}
 
-        if row_content_type == 'text/csv':
-            cast = '::text'
-        else:
-            cast = ''
-
         for attribute, col, base in self.attributes:
             if base == self.epath:
                 # column in final entity path element
@@ -1187,7 +1182,7 @@ class AttributePath (AnyPath):
             else:
                 select = "%s.%s" % (alias, col.sql_name())
 
-            select = select + cast
+            select = select
 
             if attribute.alias is not None:
                 if unicode(attribute.alias) in outputs:
@@ -1371,11 +1366,6 @@ class AttributeGroupPath (AnyPath):
         else:
             page_filters = 'WHERE %s' % (' AND '.join(page_filters))
 
-        if row_content_type == 'text/csv':
-            groupkeys = map(lambda k: '%s::text' % k, groupkeys)
-            extras = map(lambda k: '%s::text' % k, extras)
-            aggregates = map(lambda a: ('%s::text' % a[0], a[1]), aggregates)
-
         if extras:
             # an impure aggregate query includes extras which must be reduced 
             # by an arbitrary DISTINCT ON and joined to the core aggregate query
@@ -1542,11 +1532,6 @@ class AggregatePath (AnyPath):
         aggregates, extras = self._sql_get_agg_attributes(allow_extra=False)
         asql, sort, page_filters = apath.sql_get(split_sort=True, distinct_on=False)
 
-        if row_content_type == 'text/csv':
-            cast = '::text'
-        else:
-            cast = ''
-
         # a pure aggregate query has aggregates
         sql = """
 SELECT %(aggs)s
@@ -1554,7 +1539,7 @@ FROM ( %(asql)s ) s
 """
         return sql % dict(
             asql=asql,
-            aggs=', '.join([ '%s%s AS %s' % (a[0], cast, a[1]) for a in aggregates]),
+            aggs=', '.join([ '%s AS %s' % (a[0], a[1]) for a in aggregates]),
             )
 
 class QueryPath (object):

--- a/ermrest/ermpath/resource.py
+++ b/ermrest/ermpath/resource.py
@@ -90,6 +90,81 @@ def notify_data_change(cur, table):
     for table in tables:
         cur.execute('SELECT _ermrest.data_change_event(%s, %s)' % (sql_literal(table.schema.name), sql_literal(table.name)))
 
+def page_filter_sql(keynames, descendings, types, boundary, is_before):
+    """Return SQL WHERE clause to filter by page boundary.
+
+       Keycols, descendings, types, boundary are arrays of length N
+       characterizing N-length page key.
+
+       keynames: the names of the SQL data columns used for sorting
+         and paging in result set
+
+       descendings: True if column is sorted in descending order,
+         False if sorted in ascending order
+
+       types: the type object for columns to use when serializing key
+         values.
+
+       boundary: value or None for each page key component
+
+       is_before: True for '@before(boundary)', False for
+         '@after(boundary)'.
+
+    """
+    assert len(keynames) == len(descendings)
+    assert len(keynames) == len(boundary)
+    
+    def helper(keynames, descendings, types, boundary):
+        if descendings[0]:
+            ops = {True: '>', False: '<'}
+        else:
+            ops = {True: '<', False: '>'}
+            
+        term = '%s %s %s' % (
+            sql_identifier(keynames[0]),
+            ops[is_before],
+            boundary[0].sql_literal(types[0]) if not boundary[0].is_null() else 'NULL'
+        )
+        
+        if len(keynames) == 1:
+            if boundary[0].is_null():
+                if is_before:
+                    # all non-NULLs come before NULL
+                    return '%s IS NOT NULL' % sql_identifier(keynames[0])
+                else:
+                    # nothing comes after NULL
+                    return 'False'
+            else:
+                if is_before:
+                    return term
+                else:
+                    # NULLs come after non-NULL page key
+                    return '(%s OR %s IS NULL)' % (term, sql_identifier(keynames[0]))
+        else:
+            sub_filter = helper(keynames[1:], descendings[1:], types[1:], boundary[1:])
+            if boundary[0].is_null():
+                if is_before:
+                    # all non-NULLs come before NULL
+                    return '%s IS NOT NULL' % sql_identifier(keynames[0])
+                else:
+                    # minor sub-keys may put rows after ours
+                    return '%s IS NULL AND (%s)' % (sql_identifier(keynames[0]), sub_filter)
+            else:
+                # minor sub-keys may put rows beyond ours when our key is equal
+                oterm = '(%s) OR (%s = %s AND %s)' % (
+                    term,
+                    sql_identifier(keynames[0]), boundary[0].sql_literal(types[0]),
+                    sub_filter
+                )
+                if is_before:
+                    return oterm
+                else:
+                    # NULLs come after non-NULL page key
+                    return '(%s OR %s IS NULL)' % (oterm, sql_identifier(keynames[0]))
+
+    result = helper(keynames, descendings, types, boundary)
+    return result
+        
 
 class EntityElem (object):
     """Wrapper for instance of entity table in path.
@@ -680,10 +755,11 @@ class AnyPath (object):
         # TODO: refactor this common code between 
 
         sql = self.sql_get(row_content_type=content_type)
-        #web.debug(sql)
 
         if limit is not None:
             sql += (' LIMIT %d' % limit)
+
+        #web.debug(sql)
 
         if output_file:
             # efficiently send results to file
@@ -726,6 +802,9 @@ class EntityPath (AnyPath):
         self._path = None
         self._context_index = None
         self.sort = None
+        self.page_filters = []
+        self.after = None
+        self.before = None
         self.aliases = {}
 
     def __str__(self):
@@ -810,6 +889,9 @@ WHERE %(pred)s
             self.sort = None
         else:
             parts = []
+            self.page_keys = []
+            self.page_desc = []
+            self.page_type = []
             for key in sort:
                 if key.keyname not in table.columns:
                     raise ConflictModel('Sort key "%s" not found in table "%s".' % (key.keyname, table.name))
@@ -818,9 +900,20 @@ WHERE %(pred)s
                         { True: ' DESC'}.get(key.descending, '')
                         )
                               )
+                self.page_keys.append( key.keyname )
+                self.page_desc.append( key.descending )
+                self.page_type.append( table.columns[key.keyname].type )
 
             self.sort = 'ORDER BY ' + ', '.join(parts)
 
+    def add_paging(self, after, before):
+        """Add page key specification(s) for the final output.
+        """
+        if after is not None:
+            self.page_filters.append( page_filter_sql(self.page_keys, self.page_desc, self.page_type, after, is_before=False) )
+        if before is not None:
+            self.page_filters.append( page_filter_sql(self.page_keys, self.page_desc, self.page_type, before, is_before=True) )
+            
     def add_link(self, keyref, refop, ralias=None, lalias=None):
         """Extend the path by linking in another table.
 
@@ -865,7 +958,7 @@ WHERE %(pred)s
             self.aliases[ralias] = rpos
 
 
-    def sql_get(self, selects=None, sort=None, distinct_on=True, row_content_type='application/json'):
+    def sql_get(self, selects=None, sort=None, distinct_on=True, page_filters=None, row_content_type='application/json'):
         """Generate SQL query to get the entities described by this epath.
 
            The query will be of the form:
@@ -916,9 +1009,15 @@ FROM %(tables)s
 	# This subquery is ugly and inefficient but necessary due to DISTINCT ON above
 	if sort is None:
             sort = self.sort
+            
+        if page_filters is None:
+            page_filters = self.page_filters
 
     	if sort is not None:
-            sql = "SELECT * FROM (%s) s %s" % (sql, sort)
+            page = ''
+            if page_filters:
+                page = 'WHERE %s' % (' AND '.join(page_filters))
+            sql = "SELECT * FROM (%s) s %s %s" % (sql, page, sort)
 
         return sql
 
@@ -1028,6 +1127,10 @@ class AttributePath (AnyPath):
         self.epath = epath
         self.attributes = attributes
         self.sort = None
+        self.page_filters = []
+        self.after = None
+        self.before = None
+
 
     def add_sort(self, sort):
         """Add a sortlist specification for final output.
@@ -1036,6 +1139,12 @@ class AttributePath (AnyPath):
         """
         self.sort = sort
 
+    def add_paging(self, after, before):
+        """Add page key specification(s) for the final output.
+        """
+        self.after = after
+        self.before = before
+            
     def sql_get(self, split_sort=False, distinct_on=True, row_content_type='application/json'):
         """Generate SQL query to get the resources described by this apath.
 
@@ -1056,6 +1165,7 @@ class AttributePath (AnyPath):
         selects = []
 
         outputs = set()
+        output_types = {}
 
         if row_content_type == 'text/csv':
             cast = '::text'
@@ -1083,15 +1193,20 @@ class AttributePath (AnyPath):
                 if unicode(attribute.alias) in outputs:
                     raise BadSyntax('Output column name "%s" appears more than once.' % attribute.alias)
                 outputs.add(unicode(attribute.alias))
+                output_types[unicode(attribute.alias)] = col.type
                 selects.append('%s AS %s' % (select, sql_identifier(attribute.alias)))
             else:
                 if unicode(col.name) in outputs:
                     raise BadSyntax('Output column name "%s" appears more than once.' % col.name)
                 outputs.add(unicode(col.name))
+                output_types[unicode(col.name)] = col.type
                 selects.append('%s AS %s' % (select, col.sql_name()))
 
         if self.sort:
             parts = []
+            self.page_keys = []
+            self.page_desc = []
+            self.page_type = []
             for key in self.sort:
                 if key.keyname not in outputs:
                     raise BadData('Sort key "%s" not among output columns.' % key.keyname)
@@ -1100,16 +1215,25 @@ class AttributePath (AnyPath):
                         { True: ' DESC'}.get(key.descending, '')
                         )
                               )
+                self.page_keys.append( key.keyname )
+                self.page_desc.append( key.descending )
+                self.page_type.append( output_types[key.keyname] )
 
             self.sort = 'ORDER BY ' + ', '.join(parts)
 
+            if self.after:
+                self.page_filters.append( page_filter_sql(self.page_keys, self.page_desc, self.page_type, self.after, is_before=False) )
+            
+            if self.before:
+                self.page_filters.append( page_filter_sql(self.page_keys, self.page_desc, self.page_type, self.before, is_before=True) )
+            
         selects = ', '.join(selects)
 
         if split_sort:
             # let the caller compose the query and the sort clause
-            return (self.epath.sql_get(selects=selects, distinct_on=distinct_on), self.sort)
+            return (self.epath.sql_get(selects=selects, distinct_on=distinct_on), self.sort, self.page_filters)
         else:
-            return self.epath.sql_get(selects=selects, sort=self.sort, distinct_on=distinct_on)
+            return self.epath.sql_get(selects=selects, sort=self.sort, page_filters=self.page_filters, distinct_on=distinct_on)
 
     def sql_delete(self, del_columns, equery=None):
         """Generate SQL statement to delete the attributes described by this apath.
@@ -1186,6 +1310,8 @@ class AttributeGroupPath (AnyPath):
         self.groupkeys = groupkeys
         self.attributes = attributes
         self.sort = None
+        self.after = None
+        self.before = None
 
         if not groupkeys:
             raise BadSyntax('Attribute group requires at least one group key.')
@@ -1197,6 +1323,12 @@ class AttributeGroupPath (AnyPath):
         """
         self.sort = sort
 
+    def add_paging(self, after, before):
+        """Add page key specification(s) for the final output.
+        """
+        self.after = after
+        self.before = before
+            
     def sql_get(self, row_content_type='application/json'):
         """Generate SQL query to get the resources described by this apath.
 
@@ -1218,6 +1350,7 @@ class AttributeGroupPath (AnyPath):
         """
         apath = AttributePath(self.epath, self.groupkeys + self.attributes)
         apath.add_sort(self.sort)
+        apath.add_paging(self.after, self.before)
         
         groupkeys = []
         aggregates = []
@@ -1230,9 +1363,13 @@ class AttributeGroupPath (AnyPath):
                 groupkeys.append( sql_identifier(unicode(col.name)) )
 
         aggregates, extras = self._sql_get_agg_attributes()
-        asql, sort = apath.sql_get(split_sort=True, distinct_on=False)
+        asql, sort, page_filters = apath.sql_get(split_sort=True, distinct_on=False)
         if not sort:
             sort = ''
+        if not page_filters:
+            page_filters = ''
+        else:
+            page_filters = 'WHERE %s' % (' AND '.join(page_filters))
 
         if row_content_type == 'text/csv':
             groupkeys = map(lambda k: '%s::text' % k, groupkeys)
@@ -1243,16 +1380,18 @@ class AttributeGroupPath (AnyPath):
             # an impure aggregate query includes extras which must be reduced 
             # by an arbitrary DISTINCT ON and joined to the core aggregate query
             sql = """
+SELECT * FROM (
 SELECT
   %(selects)s
-FROM ( 
+FROM (
   SELECT %(groupaggs)s FROM ( %(asql)s ) s GROUP BY %(groupkeys)s
 ) g
 JOIN ( 
   SELECT DISTINCT ON ( %(groupkeys)s )
     %(groupextras)s
   FROM ( %(asql)s ) s
-) e ON ( %(joinons)s )
+) e ON ( %(joinons)s ) ) s
+%(where)s
 %(sort)s
 """
         else:
@@ -1261,11 +1400,13 @@ JOIN (
 SELECT %(groupaggs)s
 FROM ( %(asql)s ) s
 GROUP BY %(groupkeys)s
+%(where)s
 %(sort)s
 """
         return sql % dict(
             asql=asql,
             sort=sort,
+            where=page_filters,
             selects=', '.join(['g.%s' % k for k in groupkeys + [ a[1] for a in aggregates]]
                               + [ 'e.%s' % e for e in extras ]),
             groupkeys=', '.join(groupkeys),
@@ -1395,7 +1536,7 @@ class AggregatePath (AnyPath):
         """
         apath = AttributePath(self.epath, self.attributes)
         aggregates, extras = self._sql_get_agg_attributes(allow_extra=False)
-        asql, sort = apath.sql_get(split_sort=True, distinct_on=False)
+        asql, sort, page_filters = apath.sql_get(split_sort=True, distinct_on=False)
 
         if row_content_type == 'text/csv':
             cast = '::text'

--- a/ermrest/ermpath/resource.py
+++ b/ermrest/ermpath/resource.py
@@ -1530,6 +1530,10 @@ class AggregatePath (AnyPath):
         if sort:
             raise BadSyntax('Sort is meaningless for aggregates returning one row.')
 
+    def add_paging(self, before, after):
+        # to honour generic API.  actually gated on self.add_sort() above so no need to test again
+        pass
+        
     def sql_get(self, row_content_type='application/json'):
         """Generate SQL query to get the resources described by this apath.
 

--- a/ermrest/url/ast/__init__.py
+++ b/ermrest/url/ast/__init__.py
@@ -73,6 +73,9 @@ class Value (object):
         """
         pass
 
+    def is_null(self):
+        return self._str is None
+    
     def sql_literal(self, etype):
         return etype.sql_literal(self._str)
 

--- a/ermrest/url/ast/__init__.py
+++ b/ermrest/url/ast/__init__.py
@@ -51,6 +51,11 @@ class Sortkey (object):
         self.keyname = keyname
         self.descending = descending
 
+class PageList (list):
+    """Represent a list of page key values
+    """
+    pass
+
 class Value (object):
     """Represent a literal value in an ERMREST URL.
 

--- a/ermrest/url/ast/api.py
+++ b/ermrest/url/ast/api.py
@@ -35,6 +35,8 @@ class Api (object):
         self.catalog = catalog
         self.queryopts = dict()
         self.sort = None
+        self.before = None
+        self.after = None
         self.http_vary = web.ctx.webauthn2_manager.get_http_vary()
         self.http_etag = None
 
@@ -86,6 +88,24 @@ class Api (object):
 
     def with_sort(self, sort):
         self.sort = sort
+        return self
+
+    def with_before(self, before):
+        self.before = before
+        if len(before) != len(self.sort):
+            raise rest.BadRequest(
+                'The "before" page key of length %d does not match the "sort" key of length %d.'
+                % (len(before), len(self.sort))
+            )
+        return self
+
+    def with_after(self, after):
+        self.after = after
+        if len(after) != len(self.sort):
+            raise rest.BadRequest(
+                'The "after" page key of length %d does not match the "sort" key of length %d.'
+                % (len(after), len(self.sort))
+            )
         return self
 
     def negotiated_limit(self):

--- a/ermrest/url/ast/data/__init__.py
+++ b/ermrest/url/ast/data/__init__.py
@@ -73,6 +73,7 @@ def _GET(handler, uri, dresource, vresource):
         handler.set_http_etag( vresource.get_data_version(cur) )
         handler.http_check_preconditions()
         dresource.add_sort(handler.sort)
+        dresource.add_paging(handler.after, handler.before)
         return dresource.get(conn, cur, content_type=content_type, limit=limit)
 
     def post_commit(lines):

--- a/ermrest/url/lex.py
+++ b/ermrest/url/lex.py
@@ -58,10 +58,12 @@ literals = [
 # special strings which can be keywords when parsing
 keywords = [
     'acl',
+    'after',
     'aggregate',
     'annotation',
     'attribute',
     'attributegroup',
+    'before',
     'catalog',
     'ciregexp',
     'column',

--- a/ermrest/url/parse.py
+++ b/ermrest/url/parse.py
@@ -116,6 +116,23 @@ def p_sortlist_grow(p):
     p[0] = p[1]
     p[0].append( p[3] )
 
+def p_data_page_before(p):
+    """datasort : datasort '@' BEFORE '(' pagelist ')' """
+    p[0] = p[1].with_before(p[5])
+
+def p_data_page_after(p):
+    """datasort : datasort '@' AFTER '(' pagelist ')' """
+    p[0] = p[1].with_after(p[5])
+
+def p_pagelist(p):
+    """pagelist : pageitem"""
+    p[0] = ast.PageList([ p[1] ])
+
+def p_pagelist_grow(p):
+    """pagelist : pagelist ',' pageitem"""
+    p[0] = p[1]
+    p[0].append( p[3] )
+    
 def p_meta_key(p):
     """meta : catalogslash META '/' string slashopt """
     p[0] = p[1].meta(p[4])
@@ -256,6 +273,18 @@ def p_sortitem(p):
 def p_sortitem_descending(p):
     """sortitem : string OPMARK DESC OPMARK"""
     p[0] = ast.Sortkey(p[1], True)
+
+def p_pageitem(p):
+    """pageitem : string"""
+    p[0] = ast.Value(p[1])
+
+def p_pageitem_null(p):
+    """pageitem : OPMARK NULL OPMARK"""
+    p[0] = ast.Value(None)
+
+def p_pageitem_empty(p):
+    """pageitem : """
+    p[0] = ast.Value('')
 
 def p_bname_grow(p):
     """bname : bname ':' string"""


### PR DESCRIPTION
This adds paging modifiers to the REST API, documents them, and adds test cases.  They are supported on the `/entity/`, `/attribute/`, and `/attributegroup/` APIs since they complement the result row sort modifier function that already exists on those APIs.

@robes @shinyichen I think this is ready to review, test, and merge. Maybe we should switch our dev VM to run this branch of ERMrest for a while?