### PR TITLE
modify introspection of domain and user-defined types

### DIFF
--- a/ermrest/catalog.py
+++ b/ermrest/catalog.py
@@ -342,6 +342,8 @@ CREATE TABLE %(schema)s.%(table)s (
     snap_txid bigint PRIMARY KEY
 );
 
+CREATE DOMAIN longtext text;
+
 CREATE OR REPLACE FUNCTION %(schema)s.current_client() RETURNS text STABLE AS $$
 BEGIN
   RETURN current_setting('webauthn2.client');

--- a/ermrest/ermrest_config.json.in
+++ b/ermrest/ermrest_config.json.in
@@ -63,6 +63,7 @@
         "int4": { "aliases": [ "integer", "int" ] },
         "int8": { "aliases": [ "bigint" ] },
         "interval": null,
+	"longtext": null,
         "serial2": { "aliases": [ "smallserial" ] },
         "serial4": { "aliases": [ "serial" ] },
         "serial8": { "aliases": [ "bigserial" ] },


### PR DESCRIPTION
Changes:

1. Reveal domain type names rather than their base type
2. For domains over array types, apply heuristic
  - If domain name is "...[]", treat "..." prefix as element type name
  - Otherwise: dig down to element type of base storage type
3. Reveal user-defined type names rather than `USER-DEFINED` constant
  - As outer array type
  - As element type of arrays

Purpose:

We can start experimenting with using domains to represent semantic
subtypes of regular storage types.

1. Update your service code to this revision
2. Run `CREATE DOMAIN longtext text;` in your catalog DB
3. Edit your ermrest_config.json to add `"longtext": null` to your `column_types` mapping rule
4. Create a table using `longtext` column type
5. See `longtext` returned in introspection

Array domains hack:

Currently you cannot make an array of domain values. But, you can
define a domain over an array type, so the above heuristics would
allow `CREATE DOMAIN "longtext[]" text[];` to work.

The difficulty with this is that advanced features like check
constraints in a domain definition will need to be written differently
to evaluate over the array of values. Postgres will not let you
compose an existing domain into an array of domain values to get each
array member individually validated by domain constraints.

If you're just using the domain to define a semantic alias for a
storage type, then this distinction won't matter so much.