### PR TITLE
revert to single-role deployment model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 PLATFORM=centos7
 
 PGADMIN=postgres
-DAEMONUSER1=ermrestddl
-DAEMONUSER2=ermrest
+DAEMONUSER=ermrest
 USERADD=true
 USERDEL=false
 CREATEUSER=true

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ See [ERMrest Installation (CentOS 6)](user-doc/install-centos7.md).
 ### Operational Model
 
 1. The HTTPS connection is terminated by Apache HTTPD.
-1. The ERMrest service code executes as a daemon user
-  - Catalog and schema management operations execute as the `ermrestddl` daemon user.
-  - Data access operations execute as the `ermrest` daemon user.
+1. The ERMrest service code executes as the `ermrest` daemon user
 1. The service configuration is loaded from `~ermrest/ermrest_config.json`:
   - Security provider configuration via embedded webauthn configuration data (will change in future)
   - Core access control policy for catalog creation.

--- a/ermrest/catalog.py
+++ b/ermrest/catalog.py
@@ -280,12 +280,11 @@ SELECT txid_current();
         """
         if type(owner) is dict:
             owner = owner['id']
-        
+
         # create schema, if it doesn't exist
         if not schema_exists(cur, self._SCHEMA_NAME):
             cur.execute("""
 CREATE SCHEMA %(schema)s;
-GRANT USAGE ON SCHEMA %(schema)s TO ermrest;
 """ % dict(schema=self._SCHEMA_NAME)
                         )
             
@@ -469,16 +468,6 @@ $$ LANGUAGE plpgsql;
            table=self._DATA_VERSION_TABLE_NAME)
                         )
 
-        cur.execute("""
-GRANT SELECT -- INSERT, UPDATE, DELETE
-  ON _ermrest.meta, _ermrest.model_pseudo_key, _ermrest.model_pseudo_keyref
-  TO ermrest;
-GRANT SELECT, INSERT, UPDATE, DELETE
-  ON _ermrest.model_version, _ermrest.data_version 
-  TO ermrest;
-GRANT ALL ON ALL SEQUENCES IN SCHEMA _ermrest TO ermrest;
-""")
-            
         ## initial meta values
         owner = owner if owner else self.ANONYMOUS
         self.add_meta(cur, self.META_OWNER, owner)

--- a/ermrest/makefile-rules
+++ b/ermrest/makefile-rules
@@ -8,7 +8,7 @@ $(SHAREDIR)/ermrest_config.json: ermrest/ermrest_config.json.in config/make-vars
 
 $(SHAREDIR)/wsgi_ermrest.conf: ermrest/wsgi_ermrest.conf.in config/make-vars-$(PLATFORM)
 	./install-script -M sed -R @PYLIBDIR@=$(PYLIBDIR) @WSGISOCKETPREFIX@=$(WSGISOCKETPREFIX) \
-		@DAEMONUSER1@=$(DAEMONUSER1) @DAEMONUSER2@=$(DAEMONUSER2) \
+		@DAEMONUSER@=$(DAEMONUSER) \
 		@HTMLDIR@=$(HTMLDIR) @AUTHDIRECTIVES@="$(AUTHDIRECTIVES)" \
 		-o root -g root -m a+r -p -D $< $@
 

--- a/ermrest/model/misc.py
+++ b/ermrest/model/misc.py
@@ -144,7 +144,6 @@ DELETE FROM _ermrest.model_%s_annotation WHERE %s;
         keys = keying.keys() + ['annotation_uri']
         cur.execute("""
 CREATE TABLE _ermrest.model_%(restype)s_annotation (%(cols)s);
-GRANT SELECT ON _ermrest.model_%(restype)s_annotation TO ermrest;
 """ % dict(
     restype=restype,
     cols=', '.join([ '%s %s NOT NULL' % (sql_identifier(k), keying.get(k, ('text', None))[0]) for k in keys ]

--- a/ermrest/model/schema.py
+++ b/ermrest/model/schema.py
@@ -67,7 +67,6 @@ class Model (object):
             raise exception.ConflictModel('Requested schema %s already exists.' % sname)
         cur.execute("""
 CREATE SCHEMA %(schema)s ;
-GRANT USAGE ON SCHEMA %(schema)s TO ermrest;
 SELECT _ermrest.model_change_event();
 """ % dict(schema=sql_identifier(sname)))
         return Schema(self, sname)
@@ -103,7 +102,6 @@ SELECT _ermrest.model_change_event();
 DROP TABLE IF EXISTS _ermrest.valuemap ;
 CREATE TABLE _ermrest.valuemap ("schema", "table", "column", "value")
 AS %s ;
-GRANT SELECT ON _ermrest.valuemap TO ermrest;
 CREATE INDEX _ermrest_valuemap_cluster_idx ON _ermrest.valuemap ("schema", "table", "column");
 CREATE INDEX _ermrest_valuemap_value_idx ON _ermrest.valuemap USING gin ( "value" gin_trgm_ops );
 """ % ' UNION '.join(vmap_parts)

--- a/ermrest/model/table.py
+++ b/ermrest/model/table.py
@@ -126,8 +126,6 @@ CREATE TABLE %(sname)s.%(tname)s (
    %(clauses)s
 );
 COMMENT ON TABLE %(sname)s.%(tname)s IS %(comment)s;
-GRANT ALL ON TABLE %(sname)s.%(tname)s TO ermrest;
-GRANT ALL ON ALL SEQUENCES IN SCHEMA %(sname)s TO ermrest;
 SELECT _ermrest.model_change_event();
 SELECT _ermrest.data_change_event(%(snamestr)s, %(tnamestr)s);
 """ % dict(sname=sql_identifier(sname),

--- a/ermrest/registry.py
+++ b/ermrest/registry.py
@@ -146,7 +146,6 @@ class SimpleRegistry(Registry):
             # create registry schema, if it doesn't exist
             cur.execute("""
 CREATE SCHEMA IF NOT EXISTS ermrest;
-GRANT USAGE ON SCHEMA ermrest TO ermrest;
 """)
 
             # create registry table, if it doesn't exist
@@ -161,7 +160,6 @@ CREATE TABLE ermrest.simple_registry (
 CREATE INDEX ON ermrest.simple_registry (deleted_on);
 CREATE INDEX ON ermrest.simple_registry (id, deleted_on);
 CREATE INDEX ON ermrest.simple_registry (created_on);
-GRANT SELECT ON ermrest.simple_registry TO ermrest;
 """)
             return None
         return self.pooled_perform(body)

--- a/ermrest/wsgi_ermrest.conf.in
+++ b/ermrest/wsgi_ermrest.conf.in
@@ -2,8 +2,7 @@
 AllowEncodedSlashes On
 
 WSGIPythonOptimize 1
-WSGIDaemonProcess @DAEMONUSER1@ processes=1 threads=1 user=@DAEMONUSER1@ maximum-requests=2000
-WSGIDaemonProcess @DAEMONUSER2@ processes=1 threads=4 user=@DAEMONUSER2@ maximum-requests=2000
+WSGIDaemonProcess @DAEMONUSER@ processes=1 threads=1 user=@DAEMONUSER@ maximum-requests=2000
 WSGIScriptAlias /ermrest @PYLIBDIR@/ermrest/ermrest.wsgi
 WSGIPassAuthorization On
 
@@ -13,17 +12,9 @@ Alias /ermrest/static @HTMLDIR@/static
 
 <Location "/ermrest" >
    @AUTHDIRECTIVES@
-   WSGIProcessGroup @DAEMONUSER1@
+   WSGIProcessGroup @DAEMONUSER@
     
    # site can disable redundant service logging by adding env=!dontlog to their CustomLog or similar directives
    SetEnv dontlog
 </Location>
-
-<LocationMatch "/ermrest/catalog/[^/]+/(entity|attribute|attributegroup|aggregate)" >
-   @AUTHDIRECTIVES@
-   WSGIProcessGroup @DAEMONUSER2@
-    
-   # site can disable redundant service logging by adding env=!dontlog to their CustomLog or similar directives
-   SetEnv dontlog
-</LocationMatch>
 

--- a/sbin/ermrest-db-work
+++ b/sbin/ermrest-db-work
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 
-# Copyright 2012-2013 University of Southern California
+# Copyright 2012-2017 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ SU=su
 
 # named parameters that can be set by caller or on command-line above to override defaults...
 
-DAEMONUSER="${DAEMONUSER:-ermrestddl}" # Unix and DB user name for service daemon
+DAEMONUSER="${DAEMONUSER:-ermrest}" # Unix and DB user name for service daemon
 
 # make these available to child processes
 export PGADMIN

--- a/sbin/ermrest-deploy
+++ b/sbin/ermrest-deploy
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 
-# Copyright 2012-2013 University of Southern California
+# Copyright 2012-2017 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,8 +41,7 @@ SU=su
 DEPLOYLOCK="${DEPLOYLOCK}"          # deploy mutual-exclusion marker, if non-empty
 
 PGADMIN="${PGADMIN:-postgres}"
-DAEMONUSER1="${DAEMONUSER:-ermrestddl}" # Unix and DB user name for service daemon doing DDL
-DAEMONUSER2="${DAEMONUSER:-ermrest}"    # Unix and DB user name for service daemon doing SQL
+DAEMONUSER="${DAEMONUSER:-ermrest}" # Unix and DB user name for service daemon doing DDL
 
 # make these available to child processes
 export PGADMIN
@@ -57,14 +56,11 @@ cleanup()
 
 trap cleanup 0
 
-id ${DAEMONUSER1} || useradd -m -r ${DAEMONUSER1}
-id ${DAEMONUSER2} || useradd -m -r ${DAEMONUSER2}
+id ${DAEMONUSER} || useradd -m -r ${DAEMONUSER}
 
-usermod -a -G apache ${DAEMONUSER1}
-usermod -a -G apache ${DAEMONUSER2}
+usermod -a -G apache ${DAEMONUSER}
 
-chmod og+rx /home/${DAEMONUSER1}
-chmod og+rx /home/${DAEMONUSER2}
+chmod og+rx /home/${DAEMONUSER}
 
 pgid()
 {
@@ -81,26 +77,25 @@ pgcreateuser()
     $SU -c "createuser $*" - ${PGADMIN}
 }
 
-pgid ${DAEMONUSER1} || pgcreateuser -d -R -S ${DAEMONUSER1}
-pgid ${DAEMONUSER2} || pgcreateuser -D -R -S ${DAEMONUSER2}
-$SU -c "psql -c 'grant ermrest to ermrestddl'" - ${PGADMIN}
+pgid ${DAEMONUSER} || pgcreateuser -d -R -S ${DAEMONUSER}
 $SU -c "psql -c 'grant webauthn to ermrest'" - ${PGADMIN}
-$SU -c "psql -c 'grant webauthn to ermrestddl'" - ${PGADMIN}
 
 if [[ -r /etc/redhat-release ]]
 then
     SEMANAGE_HTTPD_SYS_CONTENT_T=httpd_sys_content_t
     
-    for daemon in ${DAEMONUSER1} ${DAEMONUSER2}
-    do
-	semanage fcontext --add --ftype d --type "${SEMANAGE_HTTPD_SYS_CONTENT_T}" "/home/${daemon}"
-	semanage fcontext --add --type "${SEMANAGE_HTTPD_SYS_CONTENT_T}" "/home/${daemon}/ermrest_config.json"
-	restorecon -v /home/${daemon}
-	setsebool -P httpd_enable_homedirs on
-    done
+    semanage fcontext --add --ftype d --type "${SEMANAGE_HTTPD_SYS_CONTENT_T}" "/home/${DAEMONUSER}"
+    semanage fcontext --add --type "${SEMANAGE_HTTPD_SYS_CONTENT_T}" "/home/${DAEMONUSER}/ermrest_config.json"
+    restorecon -v /home/${DAEMONUSER}
+    setsebool -P httpd_enable_homedirs on
 fi
 
-[[ ! -r ${HTTPCONFDIR}/wsgi_ermrest.conf ]] && cp ${SHAREDIR}/wsgi_ermrest.conf ${HTTPCONFDIR}/.
+if [[ ! -r ${HTTPCONFDIR}/wsgi_ermrest.conf ]] || grep -q ermrestddl ${HTTPCONFDIR}/wsgi_ermrest.conf
+then
+    # install default config
+    # or override conflicting legacy ermrestddl split config
+    cp ${SHAREDIR}/wsgi_ermrest.conf ${HTTPCONFDIR}/.
+fi
 
 pgdbid()
 {
@@ -116,24 +111,21 @@ pg_upgrade_catalog_sql()
 {
     cat <<EOF
 BEGIN;
-ALTER DATABASE "$1" OWNER TO ${DAEMONUSER1};
-GRANT CREATE ON DATABASE "$1" TO ${DAEMONUSER2};
+ALTER DATABASE "$1" OWNER TO ${DAEMONUSER};
 EOF
 
     $SU -c "psql -q -t -A -c \"SELECT nspname FROM pg_namespace WHERE nspname NOT IN ('pg_toast', 'pg_catalog', 'information_schema') AND NOT pg_is_other_temp_schema(oid)\" '$1'" - ${PGADMIN} | {
 	while read schema
 	do
 	    cat <<EOF
-ALTER SCHEMA "$schema" OWNER TO ${DAEMONUSER1};
-GRANT USAGE ON SCHEMA "$schema" TO ${DAEMONUSER2};
+ALTER SCHEMA "$schema" OWNER TO ${DAEMONUSER};
 EOF
 	    
 	    $SU -c "psql -q -t -A -c \"select table_name from information_schema.tables where table_schema = '$schema' AND table_type = 'BASE TABLE'\" '$1'" - ${PGADMIN} | {
 		while read table
 		do
 		    cat <<EOF
-ALTER TABLE "$schema"."$table" OWNER TO ${DAEMONUSER1};
-GRANT ALL ON TABLE "$schema"."$table" TO ${DAEMONUSER2};
+ALTER TABLE "$schema"."$table" OWNER TO ${DAEMONUSER}, FORCE ROW LEVEL SECURITY;
 EOF
 		done
 	    }
@@ -142,7 +134,7 @@ EOF
 		while read table
 		do
 		    cat <<EOF
-ALTER VIEW "$schema"."$table" OWNER TO ${DAEMONUSER2};
+ALTER VIEW "$schema"."$table" OWNER TO ${DAEMONUSER};
 EOF
 		done
 	    }
@@ -151,8 +143,7 @@ EOF
 		while read sequence
 		do
 	            cat <<EOF
-ALTER SEQUENCE "$schema"."$sequence" OWNER TO ${DAEMONUSER1};
-GRANT ALL ON SEQUENCE "$schema"."$sequence" TO ${DAEMONUSER2};
+ALTER SEQUENCE "$schema"."$sequence" OWNER TO ${DAEMONUSER};
 EOF
 		done
 	    }
@@ -163,11 +154,7 @@ EOF
 COMMIT;
 
 BEGIN;
-ALTER SCHEMA _ermrest OWNER TO ${DAEMONUSER1};
-GRANT USAGE ON SCHEMA _ermrest TO ${DAEMONUSER2};
-GRANT SELECT ON ALL TABLES IN SCHEMA _ermrest TO ${DAEMONUSER2};
-GRANT ALL ON ALL SEQUENCES IN SCHEMA _ermrest TO ${DAEMONUSER2};
-GRANT INSERT, UPDATE, DELETE ON _ermrest.model_version, _ermrest.data_version TO ${DAEMONUSER2};
+ALTER SCHEMA _ermrest OWNER TO ${DAEMONUSER};
 
 CREATE OR REPLACE FUNCTION _ermrest.current_client() RETURNS text STABLE AS \$\$
 BEGIN
@@ -194,26 +181,24 @@ pg_upgrade_registry_sql()
 {
     cat <<EOF
 BEGIN;
-ALTER DATABASE ermrest OWNER TO ${DAEMONUSER1};
+ALTER ROLE ${DAEMONUSER} CREATEDB;
+ALTER DATABASE ermrest OWNER TO ${DAEMONUSER};
 CREATE SCHEMA IF NOT EXISTS ermrest;
-ALTER SCHEMA ermrest OWNER TO ${DAEMONUSER1};
-GRANT USAGE ON SCHEMA ermrest TO ${DAEMONUSER2};
-GRANT SELECT ON ermrest.simple_registry TO ${DAEMONUSER2};
-GRANT CREATE ON DATABASE ermrest TO ${DAEMONUSER2};
+ALTER SCHEMA ermrest OWNER TO ${DAEMONUSER};
 EOF
 
     $SU -c "psql -q -t -A -c \"SELECT nspname FROM pg_namespace WHERE nspname ~ '^webauthn' AND NOT pg_is_other_temp_schema(oid)\" ermrest" - ${PGADMIN} | {
 	while read schema
 	do
 	    cat <<EOF
-ALTER SCHEMA "$schema" OWNER TO ${DAEMONUSER2};
+ALTER SCHEMA "$schema" OWNER TO ${DAEMONUSER};
 EOF
 	    
 	    $SU -c "psql -q -t -A -c \"select table_name from information_schema.tables where table_schema = '$schema'\" ermrest" - ${PGADMIN} | {
 		while read table
 		do
 		    cat <<EOF
-ALTER TABLE "$schema"."$table" OWNER TO ${DAEMONUSER2};
+ALTER TABLE "$schema"."$table" OWNER TO ${DAEMONUSER};
 EOF
 		done
 	    }
@@ -222,7 +207,7 @@ EOF
 		while read sequence
 		do
 	            cat <<EOF
-ALTER SEQUENCE "$schema"."$sequence" OWNER TO ${DAEMONUSER2};
+ALTER SEQUENCE "$schema"."$sequence" OWNER TO ${DAEMONUSER};
 EOF
 		done
 	    }
@@ -236,16 +221,15 @@ EOF
 }
 
 # prevent overwrites
-[[ -r /home/${DAEMONUSER2}/ermrest_config.json ]] || $SU -c "cp -a ${SHAREDIR}/ermrest_config.json ." - "${DAEMONUSER2}"
-[[ -r /home/${DAEMONUSER1}/ermrest_config.json ]] || $SU -c "ln -s /home/${DAEMONUSER2}/ermrest_config.json ." - "${DAEMONUSER1}"
+[[ -r /home/${DAEMONUSER}/ermrest_config.json ]] || $SU -c "cp -a ${SHAREDIR}/ermrest_config.json ." - "${DAEMONUSER}"
 
 if pgdbid 'ermrest'
 then
-    # idempotently fill in missing parts and update role assignments for 2-role deployment
+    # idempotently fill in missing parts and update role assignments
     pg_upgrade_registry_sql > ${TMP_SQL}
     $SU -c "psql -e ermrest" - ${PGADMIN} < ${TMP_SQL}
 
-    $SU -c "psql -q -t -A -c \"select descriptor::json->>'dbname' from ermrest.simple_registry\" ermrest" - ${DAEMONUSER1} | {
+    $SU -c "psql -q -t -A -c \"select descriptor::json->>'dbname' from ermrest.simple_registry\" ermrest" - ${PGADMIN} | {
 	catalogs=()
 	while read line
 	do
@@ -260,13 +244,12 @@ then
 	done
     }
 else
-    $SU -c "createdb -O \"$DAEMONUSER1\" ermrest" - ${PGADMIN}
-    $SU -c "psql -e -c 'GRANT CREATE ON DATABASE ermrest TO ${DAEMONUSER2}'" - ${PGADMIN}
+    $SU -c "createdb -O \"$DAEMONUSER\" ermrest" - ${PGADMIN}
 fi
 
 
 # these are supposed to be idempotent too...
 $SU -c "createlang -d ermrest plpgsql" - "${PGADMIN}"
 $SU -c "psql -d template1 -c \"CREATE EXTENSION pg_trgm;\"" - ${PGADMIN}
-$SU -c "${SBINDIR}/ermrest-registry-deploy" - "${DAEMONUSER1}"
+$SU -c "${SBINDIR}/ermrest-registry-deploy" - "${DAEMONUSER}"
 

--- a/sbin/ermrest-valuemap-work
+++ b/sbin/ermrest-valuemap-work
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 
-# Copyright 2012-2015 University of Southern California
+# Copyright 2012-2017 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ SU=su
 
 # named parameters that can be set by caller or on command-line above to override defaults...
 
-DAEMONUSER="${DAEMONUSER:-ermrestddl}" # Unix and DB user name for service daemon
+DAEMONUSER="${DAEMONUSER:-ermrest}" # Unix and DB user name for service daemon
 
 # make these available to child processes
 export PGADMIN

--- a/test/ermrest-registry-purge-tests.sh
+++ b/test/ermrest-registry-purge-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 
-# Copyright 2012-2015 University of Southern California
+# Copyright 2012-2017 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@
 
 PROG=$(basename $0)                 # Program name
 LOG=${PROG}.log                     # Log file
-DAEMONUSER="${DAEMONUSER:-ermrestddl}" # Unix and DB user name
-MASTERDB="${MASTEDB:-ermrest}"      # Master DB name
+DAEMONUSER="${DAEMONUSER:-ermrest}" # Unix and DB user name
+MASTERDB="${MASTERDB:-$(DAEMONUSER}}" # Master DB name
 DBNPREFIX="_${MASTERDB}_test"       # DB name prefix
 
 # Define the tests that will be run:


### PR DESCRIPTION
- use `ALTER TABLE ... FORCE ROW LEVEL SECURITY` to allow RLS w/o dual roles
- converge back to single `ermrest` daemon and DB role for everything
- upgrades legacy deployments by re-running ermrest-deploy

NOTE: this slightly violates our usual norms about config files.  It
installs the new wsgi_ermrest.conf file under apache over an older
one, if the old one contains the string `ermrestddl` which would
indicate it is a legacy config that conflicts with the updated
deployment model.