### PR TITLE
* column text w/o concatenated row string

### DIFF
--- a/ermrest/catalog.py
+++ b/ermrest/catalog.py
@@ -1,5 +1,5 @@
 # 
-# Copyright 2013-2016 University of Southern California
+# Copyright 2013-2017 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -343,12 +343,36 @@ CREATE DOMAIN longtext text;
 CREATE DOMAIN markdown text;
 CREATE DOMAIN gene_sequence text;
 
-CREATE OR REPLACE FUNCTION %(schema)s.ts_iso8601(anynonarray) RETURNS text IMMUTABLE AS $$
+CREATE OR REPLACE FUNCTION %(schema)s.astext(timestamptz) RETURNS text IMMUTABLE AS $$
   SELECT to_char($1 AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"');
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION %(schema)s.ts_iso8601(anyarray) RETURNS text IMMUTABLE AS $$
-  SELECT array_agg(%(schema)s.ts_iso8601(v))::text FROM unnest($1) s(v);
+CREATE OR REPLACE FUNCTION %(schema)s.astext(timestamp) RETURNS text IMMUTABLE AS $$
+  SELECT to_char($1, 'YYYY-MM-DD"T"HH24:MI:SS');
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION %(schema)s.astext(timetz) RETURNS text IMMUTABLE AS $$
+  SELECT to_char(date_part('hour', $1 AT TIME ZONE 'UTC'), '09') 
+     || ':' || to_char(date_part('minute', $1 AT TIME ZONE 'UTC'), '09') 
+     || ':' || to_char(date_part('second', $1 AT TIME ZONE 'UTC'), '09');
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION %(schema)s.astext(time) RETURNS text IMMUTABLE AS $$
+  SELECT to_char(date_part('hour', $1), '09') 
+     || ':' || to_char(date_part('minute', $1), '09') 
+     || ':' || to_char(date_part('second', $1), '09');
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION %(schema)s.astext(date) RETURNS text IMMUTABLE AS $$
+  SELECT to_char($1, 'YYYY-MM-DD');
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION %(schema)s.astext(anyarray) RETURNS text IMMUTABLE AS $$
+  SELECT array_agg(%(schema)s.astext(v))::text FROM unnest($1) s(v);
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION %(schema)s.astext(anynonarray) RETURNS text IMMUTABLE AS $$
+  SELECT $1::text;
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION %(schema)s.current_client() RETURNS text STABLE AS $$

--- a/ermrest/ermrest_config.json.in
+++ b/ermrest/ermrest_config.json.in
@@ -33,7 +33,10 @@
         "serial4": { "aliases": [ "serial" ] },
         "serial8": { "aliases": [ "bigserial" ] },
         "text": { "aliases": [ "character varying" ] },
-        "timestamptz": { "aliases": [ "timestamptz", "timestamp with time zone" ] },
+        "timestamptz": { "aliases": [ "timestamp with time zone" ] },
+        "timestamp": { "aliases": [ "timestamp without time zone" ] },
+        "timetz": { "aliases": [ "time with time zone" ] },
+        "time": { "aliases": [ "time without time zone" ] },
         "uuid": null,
 	"json": null,
 	"jsonb": null
@@ -45,9 +48,7 @@
         "text": {
             "aliases": [ "char", "bpchar", "varchar" ],
             "regexps": [ "(text|character)( +varying)?( *[(][0-9]+[)])?$" ]
-            },
-        "time": { "aliases": [ "time with time zone", "time without time zone" ] },
-        "timestamp": { "aliases": [ "timestamp without time zone" ] }
+            }
     },
 
     "change_notification": {

--- a/ermrest/url/ast/data/predicate.py
+++ b/ermrest/url/ast/data/predicate.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2015 University of Southern California
+# Copyright 2013-2017 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -119,24 +119,30 @@ class BinaryTextPredicate (BinaryPredicate):
     def _sql_left_value(self):
         """Generate SQL column value expression to allow overriding by subclasses."""
         if hasattr(self.left_col, 'sql_name_astext_with_talias'):
-            name = self.left_col.sql_name_astext_with_talias('t%d' % self.left_elem.pos)
+            return self.left_col.sql_name_astext_with_talias('t%d' % self.left_elem.pos)
         else:
-            name = "t%d.%s" % (
+            return "t%d.%s::%s" % (
                 self.left_elem.pos,
-                self.left_col.sql_name()
-                )
-        return "%s::%s" % (name, self._sql_left_type)
+                self.left_col.sql_name(),
+                self._sql_left_type
+            )
 
     def _sql_right_value(self):
         return self.right_expr.sql_literal(model.text_type)
 
     def sql_where(self, epath, elem):
-        return '%s %s %s' % (
-            self._sql_left_value(),
-            self.sqlop,
-            self._sql_right_value()
+        def where_one(left):
+            return '(%s %s %s)' % (
+                left,
+                self.sqlop,
+                self._sql_right_value()
             )
-
+            
+        left = self._sql_left_value()
+        if type(left) is set:
+            return '(%s)' % ' OR '.join(map(where_one, left))
+        else:
+            return where_one(left)
 
 _ops = dict()
 
@@ -190,7 +196,13 @@ class TextsearchPredicate (BinaryTextPredicate):
     sqlop = '@@'
 
     def _sql_left_value(self):
-        return 'to_tsvector(%s)' % BinaryTextPredicate._sql_left_value(self)
+        def wrap(left):
+            'to_tsvector(%s)' % left
+        left = BinaryTextPredicate._sql_left_value(self)
+        if type(left) is set:
+            return set(map(wrap, left))
+        else:
+            return wrap(left)
 
     def _sql_right_value(self):
         return 'to_tsquery(%s)' % BinaryTextPredicate._sql_right_value(self)

--- a/sbin/ermrest-deploy
+++ b/sbin/ermrest-deploy
@@ -168,12 +168,44 @@ CREATE OR REPLACE FUNCTION _ermrest.current_attributes() RETURNS text[] STABLE A
   SELECT current_setting('webauthn2.attributes_array')::text[];
 \$\$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION _ermrest.ts_iso8601(anynonarray) RETURNS text IMMUTABLE AS \$\$
+DROP FUNCTION IF EXISTS _ermrest.ts_iso8601(anynonarray) CASCADE;
+DROP FUNCTION IF EXISTS _ermrest.ts_iso8601(anyarray) CASCADE;
+DROP FUNCTION IF EXISTS _ermrest.ts_iso8601(date) CASCADE;
+DROP FUNCTION IF EXISTS _ermrest.ts_iso8601(timestamptz) CASCADE;
+DROP FUNCTION IF EXISTS _ermrest.ts_iso8601(timestamp) CASCADE;
+DROP FUNCTION IF EXISTS _ermrest.ts_iso8601(timetz) CASCADE;
+DROP FUNCTION IF EXISTS _ermrest.ts_iso8601(time) CASCADE;
+
+CREATE OR REPLACE FUNCTION _ermrest.astext(timestamptz) RETURNS text IMMUTABLE AS \$\$
   SELECT to_char(\$1 AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"');
 \$\$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION _ermrest.ts_iso8601(anyarray) RETURNS text IMMUTABLE AS \$\$
-  SELECT array_agg(_ermrest.ts_iso8601(v))::text FROM unnest(\$1) s(v);
+CREATE OR REPLACE FUNCTION _ermrest.astext(timestamp) RETURNS text IMMUTABLE AS \$\$
+  SELECT to_char(\$1, 'YYYY-MM-DD"T"HH24:MI:SS');
+\$\$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _ermrest.astext(timetz) RETURNS text IMMUTABLE AS \$\$
+  SELECT to_char(date_part('hour', \$1 AT TIME ZONE 'UTC'), '09') 
+     || ':' || to_char(date_part('minute', \$1 AT TIME ZONE 'UTC'), '09') 
+     || ':' || to_char(date_part('second', \$1 AT TIME ZONE 'UTC'), '09');
+\$\$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _ermrest.astext(time) RETURNS text IMMUTABLE AS \$\$
+  SELECT to_char(date_part('hour', \$1), '09') 
+     || ':' || to_char(date_part('minute', \$1), '09') 
+     || ':' || to_char(date_part('second', \$1), '09');
+\$\$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _ermrest.astext(date) RETURNS text IMMUTABLE AS \$\$
+  SELECT to_char(\$1, 'YYYY-MM-DD');
+\$\$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _ermrest.astext(anyarray) RETURNS text IMMUTABLE AS \$\$
+  SELECT array_agg(_ermrest.astext(v))::text FROM unnest(\$1) s(v);
+\$\$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _ermrest.astext(anynonarray) RETURNS text IMMUTABLE AS \$\$
+  SELECT \$1::text;
 \$\$ LANGUAGE SQL;
 
 COMMIT;

--- a/test/rest-tests.sh
+++ b/test/rest-tests.sh
@@ -378,6 +378,9 @@ ctypes=(
     longtext
     markdown
     timestamptz
+    timestamp
+    timetz
+    time
     date
     uuid
     interval
@@ -398,7 +401,10 @@ cvals=(
     one
     oneoneoneone
     '**one**'
-    '2015-03-11T11:32:56-0700'
+    '2015-03-11T11:32:56-0000'
+    '2015-03-11T11:32:56'
+    '11:32:56-0000'
+    '11:32:56'
     '2015-03-11'
     '2648a44e-c81d-11e4-b6d7-00221930f5cc'
     'P1Y2M3DT4H5M6S'
@@ -514,6 +520,9 @@ EOF
 		;;
 	    jsonb)
 		pat='foo.%2Abar'
+		;;
+	    time*)
+		pat='56'
 		;;
 	    *)
 		pat='1'


### PR DESCRIPTION
This fixes some bugs discovered in the current master, cleaning up the recent changes to text searches via the `*` pseudo column.

This should upgrade an existing system with the following steps:
1. Pull this branch
2. `make install`
3. `make deploy`
4. re-run `ermrest-freetext-indices` as `ermrest` user

In my testing, this has essentially the same performance as the previous master, but improves support (and testing) for various column types that could trip up the current master code.

Changes (copied from sole commit in this PR):
- Replace previous ts_iso8601() procedures with more general astext()
- Expand `*` column as a set of names to disjunctively test
- Adjust default ermrest_config to handle distinguish time/timetz
- Add test cases for all configured types
- Create column indices during REST creation of tables
    - Should make queries faster
    - Helps test suite coverage

I had originally hoped to add more changes to the textfacet API but they are too slow in combination with some row-level 