### PR TITLE
Fix for regression in FKR default policy

### DIFF
--- a/ermrest/model/misc.py
+++ b/ermrest/model/misc.py
@@ -784,7 +784,10 @@ DELETE FROM _ermrest.model_%(restype)s_acl WHERE %(where)s;
         setattr(orig_class, '_acls_supported', set(acls_supported))
         setattr(orig_class, '_acls_rights', set(rights_supported))
         setattr(orig_class, '_interp_acl', _interp_acl)
-        setattr(orig_class, 'rights', rights)
+        if not hasattr(orig_class, 'rights'):
+            setattr(orig_class, 'rights', rights)
+        else:
+            setattr(orig_class, '_rights', rights)
         if not hasattr(orig_class, 'has_right'):
             setattr(orig_class, 'has_right', has_right)
         else:

--- a/test/resttest/authz_static.py
+++ b/test/resttest/authz_static.py
@@ -629,7 +629,8 @@ class AuthzT3InsertSelectFkeyInsert (Authz):
         u"insert": True
     }
     rights_T3_fkey = {
-        u"insert": True
+        u"insert": True,
+        u"update": False
     }
 
     insert_data_T3_t1id_status = 200
@@ -644,7 +645,7 @@ class AuthzT3InsertSelectFkeyUpdateOnly (AuthzT3InsertSelectFkeyInsert):
 
     rights_T3_fkey = {
         u"insert": False,
-        u"update": True,
+        u"update": False,
     }
 
     insert_data_T3_fkey_status = 403
@@ -760,6 +761,11 @@ class AuthzT3WriteCt1idInsert (AuthzT3Write):
         "delete": True,
     }
 
+    rights_T3_fkey = {
+        u"insert": True,
+        u"update": False,
+    }
+
     update_data_T3_t1id_status = 403
     write_data_T3_t1id_status = 403
     update_data_T3_fkey_status = 403
@@ -781,6 +787,11 @@ class AuthzT3WriteCt1idUpdate (AuthzT3Write):
         "update": True,
         "insert": True,
         "delete": True,
+    }
+
+    rights_T3_fkey = {
+        u"insert": False,
+        u"update": True,
     }
 
     insert_data_T3_t1id_status = 403


### PR DESCRIPTION
See also issue #184.

The FKR default static ACLs are supposed to behave the same as:

    {
      "insert": ["*"],
      "update": ["*"]
    }

meaning that when an admin does not customize an FKR policy, the user
is allowed to do whatever the table and column-level policies would
permit, subject to the normal FKR integrity checks.

This includes scenarios where the table and column have only
data-dependent policies.  The server SHOULD NOT attempt to enforce any
data-dependent FKR policy when the default policy is in effect.
However, the regression would cause this to happen, leading to an
authorization failure: the effective dynamic policy has no possible
matching value except NULL which is always allowed.

If the admin actually wishes to apply a data-dependent FKR policy,
they should override the default static ACL, e.g.:

    {
      "insert": [],
      "update": []
    }

or some other more nuanced static policy which might allow some
clients to use arbitrary FKR values while restricting others to only
those allowed by the FKR dynamic ACL bindings.

This fix includes several parts:

1. Adjusts the `fkr.has_right()` method to return `True` under default
   policy scenarios, so that enforcement now behaves as expected, without
   triggering any data-dependent FKR policy check.
2. Overrides the `fkr.rights()` summary to show `None` when the table
   or columns require data-dependent access decisions. This is not
   strictly necessary but seems less confusing for data-entry clients
   who might want to anticipate FKR picker permissions.
3. Update some test cases that were incorrectly testing the default FKR
   policy scenario, which is why this regression went undetected...