### PR TITLE
Add entity_rid API to support entity resolution by RID

### DIFF
--- a/docs/api-doc/data/naming.md
+++ b/docs/api-doc/data/naming.md
@@ -23,6 +23,14 @@ where the components in this structure are:
    - the `accept` parameter to override HTTP `Accept` header for content negotiation
    - the `defaults` and `nondefaults` parameters to modify the behavior of POST operations to the `entity` API
 
+## Entity Resolution Names
+
+The `entity_rid` resource space denotes resolvable RIDs using names of the form:
+
+- _service_ `/catalog/` _cid_ [ `@` _revision_ ] `/entity_rid/` _rid_
+
+The single _rid_ parameter is an entity reference to be resolved in the catalog or catalog snapshot. This _rid_ should be a `RID` column value observed in an entity within the catalog. The resolved resource, when found, is a concise JSON record telling the client in which table to look for a given entity. The client must then use other data-access resources, described next, to actually retrieve the entity content associated with the _rid_.
+
 ## Entity Names
 
 The `entity` resource space denotes whole entities using names of the form:

--- a/docs/api-doc/data/rest.md
+++ b/docs/api-doc/data/rest.md
@@ -4,6 +4,52 @@ The [ERMrest](http://github.com/informatics-isi-edu/ermrest) data operations man
 
 In the following examples, we illustrate the use of specific data formats. However, content negotiation allows any of the supported tabular data formats to be used in any request or response involving tabular data.
 
+## Entity Resolution
+
+The GET operation is used to resolve an externally conveyed `RID` column value, using an `entity_rid` resource data name of the form:
+
+- _service_ `/catalog/` _cid_ [ `@` _revision_ ] `/entity_rid/` _rid_
+
+On success the response for an existing entity is:
+
+    HTTP/1.1 200 OK
+	Content-Type: application/json
+	
+	{
+	  "schema_name": sname,
+	  "table_name": tname,
+	  "RID": rid
+	}
+
+This result indicates the schema name _sname and table name _tname_ where the given _rid_ can be located. Given such a result, the client may attempt to retrieve the resolved entity content via the [entity retrieval](#entity-retrieval) API using this form of resource name:
+
+- _service_ `/catalog/` _cid_ [ `@` _revision_ ] `/entity/` _sname_ `:` _tname_ `/RID=` _rid_
+
+to address the resolved entity within the same catalog or catalog snapshot it was resolved in.
+
+However, if resolution determines that the entity existed previously and no longer exists within the addressed catalog or catalog snapshot, a slightly different success response is generated:
+
+    HTTP/1.1 200 OK
+	Content-Type: application/json
+	
+	{
+	  "schema_name": sname,
+	  "table_name": tname,
+	  "RID": rid,
+	  "deleted_at": _dtime_,
+	  "last_visible_at": _vtime_,
+	  "last_visible_snaptime": _vrevision_
+	}
+
+This result indicates the _sname_ and _tname_ for the _rid_ as previously; it additionally indicates a deletion timestamp _dtime_ when the entity was removed, a last-visible timestamp _vtime_ when the entity was visible with its last pre-deletion state, and the _vrevision_ revision number of the catalog snapshot containing this last visible state. Given such a result, the client may attempt to retrieve the last-visible resolved entity content via the following resource name:
+
+- _service_ `/catalog/` _cid_ `@` _vrevision_ `/entity/` _sname_ `:` _tname_ `/RID=` _rid_
+
+to address the resolved entity within the _vrevision_ catalog snapshot containing its final visible state.
+
+Typical error response codes include:
+- 404 Not Found
+
 ## Entity Creation
 
 The POST operation is used to create new entity records in a table, using an `entity` resource data name of the form:

--- a/docs/api-doc/index.md
+++ b/docs/api-doc/index.md
@@ -245,6 +245,7 @@ The ERMrest interface supports typical HTTP operations to manage these different
       1. [Access Control List Binding Retrieval](model/rest.md#access-control-list-binding-retrieval)
       1. [Access Control List Binding Deletion](model/rest.md#access-control-list-binding-deletion)
 1. [Data operations](data/rest.md)
+   1. [Entity Resolution](data/rest.md#entity-resolution)
    1. [Entity Creation](data/rest.md#entity-creation)
    1. [Entity Creation with Defaults](data/rest.md#entity-creation-with-defaults)
    1. [Entity Update](data/rest.md#entity-update)

--- a/ermrest/apicore.py
+++ b/ermrest/apicore.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2012-2017 University of Southern California
+# Copyright 2012-2018 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ __all__ = [
 global_env = webauthn2.merge_config(
     jsonFileName='ermrest_config.json', 
     built_ins={
+        "request_timeout_s": 15.0,
         # TODO: are these used?
         # "default_limit": 100,
         # "db": "ermrest", 
@@ -286,7 +287,9 @@ def web_method():
                             raise rest.BadRequest('Program limit exceeded: %s.' % e.message.decode('utf8').strip())
                         elif e.pgcode[0:2] == 'XX':
                             raise rest.ServiceUnavailable('Internal error.')
-                        
+                        elif e.pgcode == '57014':
+                            raise rest.BadRequest('Query run time limit exceeded.')
+
                     # TODO: simplify postgres error text?
                     web.debug(e, e.pgcode, e.pgerror)
                     et, ev, tb = sys.exc_info()

--- a/ermrest/ermrest_config.json
+++ b/ermrest/ermrest_config.json
@@ -70,5 +70,6 @@
 
     "textfacet_policy": false,
     "require_primary_keys": true,
+    "request_timeout_s": 15.0,
     "default_limit" : 100
 }

--- a/ermrest/sql/ermrest_schema.sql
+++ b/ermrest/sql/ermrest_schema.sql
@@ -378,7 +378,7 @@ IF (SELECT True FROM information_schema.tables WHERE table_schema = '_ermrest_hi
   CREATE INDEX ve_resolve_idx ON _ermrest_history.visible_entities (entity_rid, during);
 
   -- logic to perform one-time conversion associated with creation of visible_entities on existing catalogs
-  CREATE FUNCTION _ermrest.htable_to_visible_entities(trid text, sname text, tname text, htname text) RETURNS void AS $$
+  CREATE OR REPLACE FUNCTION _ermrest.htable_to_visible_entities(trid text, sname text, tname text, htname text) RETURNS void AS $$
   DECLARE
     record record;
     prev_record record;
@@ -388,7 +388,7 @@ IF (SELECT True FROM information_schema.tables WHERE table_schema = '_ermrest_hi
     -- we can assume the visible_entities table contains NO records for this table yet
     prev_born := NULL;
     FOR record IN
-      EXECUTE 'SELECT * FROM _ermrest_history.' || quote_ident(htname) || ' h ORDER BY "RID", during'
+      EXECUTE 'SELECT "RID"::text, during FROM _ermrest_history.' || quote_ident(htname) || ' h ORDER BY "RID", during'
     LOOP
       IF prev_born IS NOT NULL THEN
         IF record."RID" = prev_record."RID" AND (prev_record.during -|- record.during OR prev_record.during && record.during) THEN

--- a/ermrest/sql/ermrest_schema.sql
+++ b/ermrest/sql/ermrest_schema.sql
@@ -1,6 +1,6 @@
 
 -- 
--- Copyright 2012-2017 University of Southern California
+-- Copyright 2012-2018 University of Southern California
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -376,6 +376,43 @@ IF (SELECT True FROM information_schema.tables WHERE table_schema = '_ermrest_hi
   );
   CREATE INDEX ve_open_idx ON _ermrest_history.visible_entities (table_rid, entity_rid, lower(during)) WHERE upper(during) IS NULL;
   CREATE INDEX ve_resolve_idx ON _ermrest_history.visible_entities (entity_rid, during);
+
+  -- logic to perform one-time conversion associated with creation of visible_entities on existing catalogs
+  CREATE FUNCTION _ermrest.htable_to_visible_entities(trid text, sname text, tname text, htname text) RETURNS void AS $$
+  DECLARE
+    record record;
+    prev_record record;
+    prev_record_rid text;
+    prev_born timestamptz;
+  BEGIN
+    -- we can assume the visible_entities table contains NO records for this table yet
+    prev_born := NULL;
+    FOR record IN
+      EXECUTE 'SELECT * FROM _ermrest_history.' || quote_ident(htname) || ' h ORDER BY "RID", during'
+    LOOP
+      IF prev_born IS NOT NULL THEN
+        IF record."RID" = prev_record."RID" AND (prev_record.during -|- record.during OR prev_record.during && record.during) THEN
+          -- this is a continuation of previous interval
+          record.during := prev_record.during + record.during; -- tolerate imprecise history ranges
+          prev_record := record;
+          CONTINUE;
+        ELSE
+          -- last record is final part of previous interval
+	  INSERT INTO _ermrest_history.visible_entities (entity_rid, table_rid, during)
+	  VALUES (prev_record."RID", trid, tstzrange(prev_born, upper(prev_record.during), '[)'));
+	END IF;
+      END IF;
+      -- this begins the first (or next interval if previous was flushed above)
+      prev_record := record;
+      prev_born := lower(record.during);
+    END LOOP;
+    IF prev_born IS NOT NULL THEN
+      -- flush final interval of iteration
+      INSERT INTO _ermrest_history.visible_entities (entity_rid, table_rid, during)
+      VALUES (prev_record."RID", trid, tstzrange(prev_born, upper(prev_record.during), '[)'));
+    END IF;
+  END;
+  $$ LANGUAGE plpgsql;
 END IF;
 
 IF (SELECT True FROM information_schema.tables WHERE table_schema = '_ermrest' AND table_name = 'known_columns') IS NULL THEN
@@ -1035,6 +1072,9 @@ BEGIN
       || ' REFERENCING OLD TABLE AS ' || quote_ident(otname)
       || ' FOR EACH STATEMENT EXECUTE PROCEDURE _ermrest_history.' || quote_ident('maintain_' || htname) || '();';
   END IF;
+
+  -- this function becomes a no-op under steady state operations but handles one-time resolver upgrade
+  PERFORM _ermrest.htable_to_visible_entities(table_rid, sname, tname, htname);
 
   -- skip healing if requested by caller and history table seems superficially active already
   IF htable_exists AND (new_trigger_exists OR old_trigger_exists) AND NOT heal_existing
@@ -2417,6 +2457,14 @@ LOOP
     || quote_ident(looprow.schema_name) || '.' || quote_ident(looprow.table_name)
     || ' FOR EACH ROW EXECUTE PROCEDURE _ermrest.maintain_row();';
 END LOOP;
+
+-- disable one-time conversion that MAY have been done above
+CREATE OR REPLACE FUNCTION _ermrest.htable_to_visible_entities(trid text, sname text, tname text, htname text) RETURNS void AS $$
+BEGIN
+  -- do nothing during normal operations...
+  RETURN;
+END;
+$$ LANGUAGE plpgsql;
 
 RAISE NOTICE 'Completed idempotent creation of standard ERMrest schema.';
 

--- a/ermrest/url/ast/__init__.py
+++ b/ermrest/url/ast/__init__.py
@@ -29,8 +29,6 @@ once an appropriate database connection is available.
 import urllib
 
 from .catalog import Catalogs, Catalog
-from . import model
-from . import data
 from ...model.name import Name, NameList
 from . import history
 

--- a/ermrest/url/ast/catalog.py
+++ b/ermrest/url/ast/catalog.py
@@ -22,8 +22,7 @@ import json
 import web
 import psycopg2.extensions
 
-import model
-import data
+from . import model, data, resolver
 from .api import Api, negotiated_content_type
 from ... import exception, catalog, sanepg2
 from ...apicore import web_method
@@ -168,6 +167,10 @@ class Catalog (Api):
     def query(self, qpath):
         """A query set for this catalog."""
         return data.Query(self, qpath)
+
+    def entity_rid(self, rid):
+        """An entity_rid resolver query."""
+        return resolver.EntityRidResolver(self, rid)
 
     def GET_body(self, conn, cur):
         _model = web.ctx.ermrest_catalog_model

--- a/ermrest/url/ast/history.py
+++ b/ermrest/url/ast/history.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2017 University of Southern California
+# Copyright 2017-2018 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -247,6 +247,10 @@ SELECT now(), t."RID"
 FROM _ermrest.known_tables t
 WHERE t."RID" = %(table_rid)s
   ON CONFLICT (table_rid) DO NOTHING;
+
+DELETE FROM _ermrest_history.visible_entities
+WHERE upper(during) <= %(h_until)s::timestamptz
+  AND table_rid = %(table_rid)s;
 """ % {
     'htable_name': sql_identifier(htable_name),
     'h_until': sql_literal(h_until),
@@ -267,6 +271,7 @@ DROP TABLE _ermrest_history.%(htable_name)s;
             cur.execute("""
 DELETE FROM _ermrest.table_modified WHERE table_rid = %(table_rid)s;
 DELETE FROM _ermrest.table_last_modified WHERE table_rid = %(table_rid)s;
+DELETE FROM _ermrest_history.visible_entities WHERE table_rid = %(table_rid)s;
 """ % {
     'htable_name': sql_identifier(htable_name),
     'table_rid': sql_literal(table_rid),

--- a/ermrest/url/ast/resolver.py
+++ b/ermrest/url/ast/resolver.py
@@ -1,0 +1,142 @@
+
+#
+# Copyright 2018 University of Southern California
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import web
+
+from .api import Api
+from .model import _GET, _post_commit_json
+from .history import _encode_ts
+from ...util import sql_literal, sql_identifier
+from ... import exception
+
+class EntityRidResolver (Api):
+    """Represents entity RID
+
+       URL: /ermrest/catalog/N[@rev]/entity_rid/rid
+
+    """
+    def __init__(self, catalog, rid):
+        super(EntityRidResolver, self).__init__(catalog)
+        self._resolve_rid = rid
+
+    def _table_found_or_gone(self, cur, rid, snaptime=None):
+        """Return (table_rid, gonetime) or None if not found.
+
+           table_rid is the table where rid was resolved.
+           gonetime is None when found or an earlier timestamp when gone.
+        """
+        cur.execute("""
+SELECT
+  ve.table_rid,
+  CASE WHEN ve.during @> %(snaptime)s THEN NULL ELSE upper(ve.during) END
+FROM _ermrest_history.visible_entities ve
+WHERE entity_rid = %(rid)s
+  AND (ve.during @> %(snaptime)s OR upper(ve.during) <= %(snaptime)s)
+ORDER BY during DESC
+LIMIT 1;
+""" % {
+    'rid': sql_literal(self._resolve_rid),
+    'snaptime': '%s::timestamptz' % (sql_literal(snaptime) if snaptime is not None else 'now()'),
+}
+            )
+        for row in cur:
+            return row
+        return None
+
+    def _last_visible_snaptime(self, cur, table_rid, rid, gonetime=None):
+        """Find latest catalog snapshot where rid is visible in table prior to gonetime.
+
+           This is only meaningful when resolving an entity which is gone.
+        """
+        cur.execute("""
+SELECT
+  GREATEST(
+    (SELECT m.ts
+     FROM _ermrest.model_modified m
+     WHERE m.ts < upper(h.during)
+     ORDER BY m.ts DESC
+     LIMIT 1),
+    (SELECT m.ts
+     FROM _ermrest.table_modified m
+     WHERE m.ts < upper(h.during)
+     ORDER BY m.ts DESC
+     LIMIT 1)
+  )
+FROM _ermrest_history.%(htable)s h
+WHERE h."RID" = %(rid)s
+  AND (upper(h.during) <= %(gonetime)s)
+ORDER BY h.during DESC
+LIMIT 1;
+""" % {
+    'rid': sql_literal(rid),
+    'htable': sql_identifier('t%s' % table_rid),
+    'gonetime': '%s::timestamptz' % (sql_literal(gonetime) if gonetime is not None else 'NULL'),
+}
+        )
+        return cur.fetchone()[0]
+
+    def _table_info(self, cur, table_rid, snaptime=None):
+        """Find (sname, tname) for table_rid at snaptime."""
+        cur.execute("""
+SELECT
+  (s.rowdata)->>'schema_name',
+  (t.rowdata)->>'table_name'
+FROM _ermrest_history.known_tables t
+JOIN _ermrest_history.known_schemas s ON ((t.rowdata)->>'schema_rid' = s."RID")
+WHERE t."RID" = %(table_rid)s
+  AND t.during @> %(snaptime)s
+  AND s.during @> %(snaptime)s;
+""" % {
+    'table_rid': sql_literal(table_rid),
+    'snaptime': '%s::timestamptz' % (sql_literal(snaptime) if snaptime is not None else 'now()'),
+}
+        )
+        return cur.fetchone()
+
+    def GET_body(self, conn, cur):
+        """Resolve RID"""
+        # TODO: add rights check here if we decide not to leave this public
+        row = self._table_found_or_gone(cur, self._resolve_rid, web.ctx.ermrest_history_snaptime)
+        if row is None:
+            raise exception.rest.NotFound('entity with RID=%s' % self._resolve_rid)
+
+        table_rid, gone_when = row
+
+        if gone_when is not None:
+            last_visible = self._last_visible_snaptime(cur, table_rid, self._resolve_rid, gone_when)
+            sname, tname = self._table_info(cur, table_rid, last_visible)
+        else:
+            web.debug(table_rid, web.ctx.ermrest_history_snaptime)
+            sname, tname = self._table_info(cur, table_rid, web.ctx.ermrest_history_snaptime)
+
+        prejson = {
+            'RID': self._resolve_rid,
+            'schema_name': sname,
+            'table_name': tname,
+        }
+        if gone_when is not None:
+            prejson.update({
+                'deleted_at': gone_when.isoformat(' '),
+                'last_visible_at': last_visible.isoformat(' '),
+                'last_visible_snaptime': _encode_ts(cur, last_visible),
+            })
+
+        return prejson
+
+    def GET(self, uri):
+        return _GET(self, self.GET_body, _post_commit_json)

--- a/ermrest/url/ast/resolver.py
+++ b/ermrest/url/ast/resolver.py
@@ -121,8 +121,14 @@ WHERE t."RID" = %(table_rid)s
             last_visible = self._last_visible_snaptime(cur, table_rid, self._resolve_rid, gone_when)
             sname, tname = self._table_info(cur, table_rid, last_visible)
         else:
-            web.debug(table_rid, web.ctx.ermrest_history_snaptime)
             sname, tname = self._table_info(cur, table_rid, web.ctx.ermrest_history_snaptime)
+
+        if sname == '_ermrest':
+            # for now, we act like model element RIDs are non-resolvable
+            web.ctx.ermrest_request_trace(
+                'Refusing resolution of model entity %s:%s/RID=%s' % (sname, tname, self._resolve_rid)
+            )
+            raise exception.rest.NotFound('entity with RID=%s' % self._resolve_rid)
 
         prejson = {
             'RID': self._resolve_rid,

--- a/ermrest/url/parse.py
+++ b/ermrest/url/parse.py
@@ -77,6 +77,7 @@ def p_apis(p):
              | foreignkeyref
              | foreignkeyrefslash
              | textfacet
+             | resolve_entity_rid
              | catalog_range
              | data_range
              | config_range
@@ -104,6 +105,10 @@ def p_catalog_when(p):
     cur = web.ctx.ermrest_catalog_pc.cur
     web.ctx.ermrest_history_snaptime = normalized_history_snaptime(cur, p[8])
     web.ctx.ermrest_history_amendver = current_history_amendver(cur, web.ctx.ermrest_history_snaptime)
+
+def p_resolve_entity_rid(p):
+    """resolve_entity_rid : catalogslash ENTITY_RID '/' string"""
+    p[0] = p[1].entity_rid(p[4])
 
 def p_catalog_range(p):
     """cataloghistory : catalogslash HISTORY"""


### PR DESCRIPTION
# Feature Summary

This supports one new API which is documented in this PR:
- `GET /ermrest/catalog/` _catalog_ `/entity_rid/` _rid_

This API is purely intended for machine clients. It does not provide a UX. It is expected that ermresolve will be adjusted to use this API for more efficient resolution of entities while providing the UX around content negotation of data representations or landing pages.

# Implementation

Resoltion is supported by a reverse mapping stored in the new `_ermrest_history.visible_entities` table which stores a longitudinal record of tuples `(entity_rid, table_rid, during)` representing presence of an entity during an interval of time (tstzrange).  This allows resolution in live catalogs, in snapshots, and also indication of dead entities in a live catalog.

The bulk of the changes are in the maintenance of this new reverse mapping. There are changes in the normal history maintenance trigger which also manages history storage tuples. There is also a onetime ETL to perform during upgrade of existing catalogs (during the `ermrest-deploy` step), to reconstruct the mapping from the raw history storage. This requires a separate query per source table and of course has per-query costs that scale with the size of the stored history. For large catalogs this may require significant downtime.

# Review or Discussion Topics

There are three main points of concern with this new feature:
1. It increases the stored tuple count for each new entity and increases write amplification with the extra bookkeeping needed for each entity update. This is the trade off for having index-based resolution across whole catalogs.
2. The implementation and upgrade procedure has been designed to be robust against certain abnormal catalog history scenarios, but should be tested for each legacy system prior to use in production.
   - It tolerates a RID being present in more than one table
   - It tolerates a RID being killed and then reborn in the same table
3. The policy model for resolution is simplistic due to several architectural assumptions. Any client who can `enumerate` the catalog (i.e. can use its REST API at all) can perform resolution queries and resolve **any** RID that they know or guess. After resolution, the client must use existing data APIs and authorization to actually view content of resolved entities, so other record content cannot be leaked.

I think some of the content below probably belongs in documentation somewhere. However, I am not sure we have any coherent place for such high-level guidance...?

## Information Leakage

In practice, the resolver API can leak knowledge about which RIDs exist, which tables and schemas exist, and which RIDs belong to which table. This means an attacker may be able to infer the presence of records they are not allowed to retrieve and possibly estimate the number of such records.

There are already potential scenarios where hidden model element names can be leaked during data update requests, e.g. due to integrity violations exposing underlying data dependencies on tables the client wouldn't otherwise be able to see. The commonly used model annotations which reconfigure Chaise presentation can also leak information about these hidden model elements. In the face of these risks, we recommend that catalog owners not use model element names which are too sensitive to share with all clients given `enumerate` access on a catalog. In that operating regime, the resolver API does not increase the risk of exposure of hidden model names.

The entity-specific RID does not itself encode any semantics other than insertion order. Indirectly, it exposes the record-creation workload of a community by allowing inference of how many records are created between two visible records which associate a RID and RCT value.  This risk is already present in any differentiated access scenario.  The additional exposure enabled by the resolver API is to be able to probe and find out which table houses an implied RID.

The largest risk with leakage of RID to table bindings would be a covert channel allowing one to infer semantics of a RID merely from table names, e.g. if the table name indicates a sensitive subset of a larger population of records. This risk is mitigated in ERMrest by default, because each new row gets a new RID rather than sharing RIDs between tables. Therefore, a data modeler SHOULD NOT abuse the data management APIs to synchronize RIDs across multiple tables, i.e. to create a sparse extension table which shares the same RIDs with its parent tables. Such abuse would defeat the mitigation inherent in ERMrest's default behaviors. To preserve the mitigation, an extension table should retain its normal automatically generated RIDs and have a separate foreign key column to link records to the parent table.