### PR TITLE
Model alterations

### DIFF
--- a/docs/api-doc/index.md
+++ b/docs/api-doc/index.md
@@ -211,6 +211,7 @@ The ERMrest interface supports typical HTTP operations to manage these different
       1. [Table List Retrieval](model/rest.md#table-list-retrieval)
       1. [Table Creation](model/rest.md#table-creation)
       1. [Table Retrieval](model/rest.md#table-retrieval)
+      1. [Table Alteration](model/rest.md#table-alteration)
       1. [Table Deletion](model/rest.md#table-deletion)
          1. [Column List Retrieval](model/rest.md#column-list-retrieval)
          1. [Column Creation](model/rest.md#column-creation)

--- a/docs/api-doc/index.md
+++ b/docs/api-doc/index.md
@@ -227,6 +227,7 @@ The ERMrest interface supports typical HTTP operations to manage these different
          1. [Foreign Key List Retrieval](model/rest.md#foreign-key-list-retrieval)
          1. [Foreign Key Creation](model/rest.md#foreign-key-creation)
          1. [Foreign Key Retrieval](model/rest.md#foreign-key-retrieval)
+         1. [Foreign Key Alteration](model/rest.md#foreign-key-alteration)
          1. [Foreign Key Deletion](model/rest.md#foreign-key-deletion)
    1. [Annotations](model/rest.md#annotations)
       1. [Annotation List Retrieval](model/rest.md#annotation-list-retrieval)

--- a/docs/api-doc/index.md
+++ b/docs/api-doc/index.md
@@ -207,6 +207,7 @@ The ERMrest interface supports typical HTTP operations to manage these different
    1. [Bulk Schemata and Table Creation](model/rest.md#bulk-schemata-and-table-creation)
    1. [Schema Creation](model/rest.md#schema-creation)
    1. [Schema Retrieval](model/rest.md#schema-retrieval)
+   1. [Schema Alteration](model/rest.md#schema-alteration)
    1. [Schema Deletion](model/rest.md#schema-deletion)
       1. [Table List Retrieval](model/rest.md#table-list-retrieval)
       1. [Table Creation](model/rest.md#table-creation)

--- a/docs/api-doc/index.md
+++ b/docs/api-doc/index.md
@@ -215,6 +215,7 @@ The ERMrest interface supports typical HTTP operations to manage these different
          1. [Column List Retrieval](model/rest.md#column-list-retrieval)
          1. [Column Creation](model/rest.md#column-creation)
          1. [Column Retrieval](model/rest.md#column-retrieval)
+         1. [Column Alteration](model/rest.md#column-alteration)
          1. [Column Deletion](model/rest.md#column-deletion)
          1. [Key List Retrieval](model/rest.md#key-list-retrieval)
          1. [Key Creation](model/rest.md#key-creation)

--- a/docs/api-doc/index.md
+++ b/docs/api-doc/index.md
@@ -222,6 +222,7 @@ The ERMrest interface supports typical HTTP operations to manage these different
          1. [Key List Retrieval](model/rest.md#key-list-retrieval)
          1. [Key Creation](model/rest.md#key-creation)
          1. [Key Retrieval](model/rest.md#key-retrieval)
+         1. [Key Alteration](model/rest.md#key-alteration)
          1. [Key Deletion](model/rest.md#key-deletion)
          1. [Foreign Key List Retrieval](model/rest.md#foreign-key-list-retrieval)
          1. [Foreign Key Creation](model/rest.md#foreign-key-creation)

--- a/docs/api-doc/model/rest.md
+++ b/docs/api-doc/model/rest.md
@@ -938,6 +938,8 @@ In this operation, the `application/json` _key representation_ is supplied as in
     [
       {
         "names": [ [ schema name, new constraint name ] ],
+	"on_update": new update action,
+	"on_delete": new delete action,
         "comment": new comment,
         "annotations": {
           annotation key: annotation document, ...
@@ -948,6 +950,8 @@ In this operation, the `application/json` _key representation_ is supplied as in
 The input _foreign key reference representation_ is as for key creation via the POST request. Instead of creating a new foreign key, the existing one as specified in the URL is altered to match the input representation. To be symmetric with [foreign key retrieval](#foreign-key-retrieval), the input is a JSON array with one sub-document. Each of these object fields, if present, will be processed as a target configuration for that aspect of the definition:
 
 - `names`: the _new constraint name_, i.e. second field of first element of `names` list, is a replacement constraint name
+- `on_update`: the _new update action_, e.g. one of `NO ACTION`, `RESTRICT`, `CASCADE`, `SET DEFAULT`, `SET NULL`
+- `on_delete`: the _new delete action_, e.g. one of `NO ACTION`, `RESTRICT`, `CASCADE`, `SET DEFAULT`, `SET NULL`
 - `comment`: a new comment string
 - `acls`: a replacement ACL configuration
 - `acl_bindings`: a replacement ACL binding configuration

--- a/docs/api-doc/model/rest.md
+++ b/docs/api-doc/model/rest.md
@@ -402,8 +402,6 @@ Typical error response codes include:
 The PUT operation is used to alter an existing column's definition:
 
 - _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_ `/column/` _column name_
-- _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_ `/column/` _column name_ `?update=` _fieldname_
-- _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_ `/column/` _column name_ `?update=` _fieldname_ `,` _fieldname_ ...
 
 In this operation, the `application/json` _column representation_ is supplied as input:
 
@@ -422,7 +420,7 @@ In this operation, the `application/json` _column representation_ is supplied as
       }
     }
 
-The input _column representation_ is as for column creation via the POST request. Instead of creating a new column, the existing column with _column name_ as specified in the URL is altered to match the input representation. By default, each of these fields, if present, will be processed as a target configuration for that aspect of the column definition:
+The input _column representation_ is as for column creation via the POST request. Instead of creating a new column, the existing column with _column name_ as specified in the URL is altered to match the input representation. Each of these fields, if present, will be processed as a target configuration for that aspect of the column definition:
 
 - `name`: a new name to support renaming from _column name_ to _new column name_
 - `type`: a new type to support changing from existing to new column type
@@ -433,7 +431,13 @@ The input _column representation_ is as for column creation via the POST request
 - `acls`: a replacement ACL set
 - `acl_bindings`: a replacement ACL bindings set
 
-The optional query parameter `update` can enumerate one or more comma-separated field names which the client wishes to update. The default behavior, when `update` is absent or empty, is as if each field name present in the input _column representation_ were also listed in the `update` parameter.
+Absence of a named field indicates that the existing state for that aspect of the column definition should be retained without change. For example, an input to rename a column, disallow nulls, and set a new default value would look like:
+
+    {
+      "name": "the new name",
+      "nullok": false,
+      "default": "the new default value"
+    }
 
 On success, the response is:
 
@@ -447,6 +451,8 @@ where the body content represents the column status at the end of the request.
 *NOTE*: In the case that the column name is changed with the `"name": ` _new column name_ input syntax, the returned document will indicate the new name, and subsequent access to the model resource will require using the updated URL:
 
 - _service_ `/catalog/` _cid_ [ `@` _revision_ ] `/schema/` _schema name_ `/table/` _table name_ `/column/` _new column name_
+
+The old URL will immediately start responding with a column not found error.
 
 Typical error response codes include:
 - 400 Bad Request

--- a/docs/api-doc/model/rest.md
+++ b/docs/api-doc/model/rest.md
@@ -923,6 +923,60 @@ Typical error response codes include:
 - 403 Forbidden
 - 401 Unauthorized
 
+## Foreign Key Alteration
+
+The PUT operation is used to alter an existing foreign key's definition:
+
+- _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_ `/foreignkey/` _column name_ `,` ... `/reference/` _table reference_ `/` _key column_ `,` ...
+
+In this operation, the `application/json` _key representation_ is supplied as input:
+
+    PUT /ermrest/catalog/42/schema/schema_name/table/table_name/key/column_name,.../reference/table_referenace/key_column,... HTTP/1.1
+	Host: www.example.com
+	Content-Type: application/json
+
+    [
+      {
+        "names": [ [ schema name, new constraint name ] ],
+        "comment": new comment,
+        "annotations": {
+          annotation key: annotation document, ...
+        }
+      }
+    ]
+
+The input _foreign key reference representation_ is as for key creation via the POST request. Instead of creating a new foreign key, the existing one as specified in the URL is altered to match the input representation. To be symmetric with [foreign key retrieval](#foreign-key-retrieval), the input is a JSON array with one sub-document. Each of these object fields, if present, will be processed as a target configuration for that aspect of the definition:
+
+- `names`: the _new constraint name_, i.e. second field of first element of `names` list, is a replacement constraint name
+- `comment`: a new comment string
+- `acls`: a replacement ACL configuration
+- `acl_bindings`: a replacement ACL binding configuration
+- `annotations`: a replacement annotation map
+
+Other key fields are immutable through this interface.
+
+Absence of a named field indicates that the existing state for that aspect of the definition should be retained without change. For example, an input to rename a constraint and set a comment would look like:
+
+    {
+      "names": [ ["table schema name", "the new constraint name" ] ],
+      "comment": "This is my newly named key."
+    }
+
+On success, the response is:
+
+    HTTP/1.1 200 OK
+	Content-Type: application/json
+
+    foreign key reference representation
+
+where the body content represents the foreign key status at the end of the request.
+
+Typical error response codes include:
+- 400 Bad Request
+- 404 Not Found
+- 403 Forbidden
+- 401 Unauthorized
+
 ## Foreign Key Deletion
 
 The DELETE method is used to remove a foreign key constraint from a table using any of the foreign key list or foreign key resource name forms:

--- a/docs/api-doc/model/rest.md
+++ b/docs/api-doc/model/rest.md
@@ -704,6 +704,56 @@ Typical error response codes include:
 - 403 Forbidden
 - 401 Unauthorized
 
+## Key Alteration
+
+The PUT operation is used to alter an existing key's definition:
+
+- _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_ `/key/` _key columns_
+
+In this operation, the `application/json` _key representation_ is supplied as input:
+
+    PUT /ermrest/catalog/42/schema/schema_name/table/table_name/key/key_columns HTTP/1.1
+	Host: www.example.com
+	Content-Type: application/json
+
+    {
+      "names": [ [ schema name, new constraint name ] ],
+      "comment": new comment,
+      "annotations": {
+        annotation key: annotation document, ...
+      }
+    }
+
+The input _key representation_ is as for key creation via the POST request. Instead of creating a new key, the existing key with _key columns_ as specified in the URL is altered to match the input representation. Each of these fields, if present, will be processed as a target configuration for that aspect of the definition:
+
+- `names`: the _new constraint name_, i.e. second field of first element of `names` list, is a replacement constraint name
+- `comment`: a new comment string
+- `annotations`: a replacement annotation map
+
+Other key fields are immutable through this interface. The `unique_columns` field, if present, must match the _key columns_ in the URL.
+
+Absence of a named field indicates that the existing state for that aspect of the definition should be retained without change. For example, an input to rename a key and set a comment would look like:
+
+    {
+      "names": [ ["table schema name", "the new constraint name" ] ],
+      "comment": "This is my newly named key."
+    }
+
+On success, the response is:
+
+    HTTP/1.1 200 OK
+	Content-Type: application/json
+
+    key representation
+
+where the body content represents the key status at the end of the request.
+
+Typical error response codes include:
+- 400 Bad Request
+- 404 Not Found
+- 403 Forbidden
+- 401 Unauthorized
+
 ## Key Deletion
 
 The DELETE method is used to remove a key constraint from a table or a pseudo-key constraint from a view:

--- a/docs/api-doc/model/rest.md
+++ b/docs/api-doc/model/rest.md
@@ -144,6 +144,63 @@ Typical error response codes include:
 - 403 Forbidden
 - 401 Unauthorized
 
+## Schema Alteration
+
+The PUT operation is used to alter an existing schema's definition:
+
+- _service_ `/catalog/` _cid_ `/schema/` _schema name_
+
+In this operation, the `application/json` _schema representation_ is supplied as input:
+
+    PUT /ermrest/catalog/42/schema/schema_name HTTP/1.1
+	Host: www.example.com
+	Content-Type: application/json
+
+    {
+      "schema_name": new schema name,
+      "comment": new column comment,
+      "annotations": {
+        annotation key: annotation document, ...
+      }
+    }
+
+The input _schema representation_ is as for schema creation via the POST request. Instead of creating a new schema, the existing schema with _schema name_ as specified in the URL is altered to match the input representation. Each of these fields, if present, will be processed as a target configuration for that aspect of the table definition:
+
+- `schema_name`: a new schema name to support renaming from _schema name_ to _new schema name_
+- `comment`: a new comment string
+- `annotations`: a replacement annotation map
+- `acls`: a replacement ACL set
+
+Other schema fields are immutable through this interface, and such input fields will be ignored.
+
+Absence of a named field indicates that the existing state for that aspect of the definition should be retained without change. For example, an input to rename a schema and set a comment would look like:
+
+    {
+      "schema_name": "the new name",
+      "comment": "This is my new named table."
+    }
+
+On success, the response is:
+
+    HTTP/1.1 200 OK
+	Content-Type: application/json
+
+    schema representation
+
+where the body content represents the schema status at the end of the request.
+
+*NOTE*: In the case that the schema name is changed, the returned document will indicate the new name, and subsequent access to the model resource will require using the updated URL:
+
+- _service_ `/catalog/` _cid_ [ `@` _revision_ ] `/schema/` _new schema name_
+
+The old URL will immediately start responding with a schema not found error.
+
+Typical error response codes include:
+- 400 Bad Request
+- 404 Not Found
+- 403 Forbidden
+- 401 Unauthorized
+
 ## Schema Deletion
 
 The DELETE method is used to delete a schema:
@@ -296,14 +353,14 @@ In this operation, the `application/json` _table representation_ is supplied as 
 
 The input _table representation_ is as for table creation via the POST request. Instead of creating a new table, the existing table with _table name_ as specified in the URL is altered to match the input representation. Each of these fields, if present, will be processed as a target configuration for that aspect of the table definition:
 
-- `schema_name`: an existing schema name to support moving from _schema name_ to _destination table name_
+- `schema_name`: an existing schema name to support moving from _schema name_ to _destination schema name_
 - `table_name`: a new name to support renaming from _table name_ to _new table name_
 - `comment`: a new comment string
 - `annotations`: a replacement annotation map
 - `acls`: a replacement ACL set
 - `acl_bindings`: a replacement ACL bindings set
 
-Other table fields are immutable through this interface, and any input fields will be ignored.
+Other table fields are immutable through this interface, and such input fields will be ignored.
 
 Absence of a named field indicates that the existing state for that aspect of the definition should be retained without change. For example, an input to rename a table and set a comment would look like:
 

--- a/docs/api-doc/model/rest.md
+++ b/docs/api-doc/model/rest.md
@@ -273,6 +273,66 @@ Typical error response codes include:
 - 401 Unauthorized
 - 409 Conflict
 
+## Table Alteration
+
+The PUT operation is used to alter an existing table's definition:
+
+- _service_ `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_
+
+In this operation, the `application/json` _table representation_ is supplied as input:
+
+    PUT /ermrest/catalog/42/schema/schema_name/table/table_name HTTP/1.1
+	Host: www.example.com
+	Content-Type: application/json
+
+    {
+      "schema_name": destination schema name,
+      "table_name": new table name,
+      "comment": new column comment,
+      "annotations": {
+        annotation key: annotation document, ...
+      }
+    }
+
+The input _table representation_ is as for table creation via the POST request. Instead of creating a new table, the existing table with _table name_ as specified in the URL is altered to match the input representation. Each of these fields, if present, will be processed as a target configuration for that aspect of the table definition:
+
+- `schema_name`: an existing schema name to support moving from _schema name_ to _destination table name_
+- `table_name`: a new name to support renaming from _table name_ to _new table name_
+- `comment`: a new comment string
+- `annotations`: a replacement annotation map
+- `acls`: a replacement ACL set
+- `acl_bindings`: a replacement ACL bindings set
+
+Other table fields are immutable through this interface, and any input fields will be ignored.
+
+Absence of a named field indicates that the existing state for that aspect of the definition should be retained without change. For example, an input to rename a table and set a comment would look like:
+
+    {
+      "table_name": "the new name",
+      "comment": "This is my new named table."
+    }
+
+On success, the response is:
+
+    HTTP/1.1 200 OK
+	Content-Type: application/json
+
+    table representation
+
+where the body content represents the table status at the end of the request.
+
+*NOTE*: In the case that the table name is changed or the table is relocated to a different schema, the returned document will indicate the new names, and subsequent access to the model resource will require using the updated URL:
+
+- _service_ `/catalog/` _cid_ [ `@` _revision_ ] `/schema/` _new schema name_ `/table/` _new table name_
+
+The old URL will immediately start responding with a table not found error.
+
+Typical error response codes include:
+- 400 Bad Request
+- 404 Not Found
+- 403 Forbidden
+- 401 Unauthorized
+
 ## Table Deletion
 
 The DELETE method is used to delete a table and all its content:

--- a/ermrest/model/column.py
+++ b/ermrest/model/column.py
@@ -233,8 +233,6 @@ CREATE INDEX %(index)s ON %(schema)s.%(table)s USING gin ( %(index_val)s gin_trg
         actions = []
         persists = []
 
-        update = set(columndoc.keys())
-
         if self.type.name != newcol.type.name:
             actions.append('SET DATA TYPE %s' % newcol.type.sql())
             persists.append('type_rid')

--- a/ermrest/model/column.py
+++ b/ermrest/model/column.py
@@ -226,6 +226,7 @@ CREATE INDEX %(index)s ON %(schema)s.%(table)s USING gin ( %(index_val)s gin_trg
         will mutate the model aspect to reach that state.
 
         """
+        self.enforce_right('owner')
         # allow sparse update documents as a (not so restful) convenience
         newdoc = self.prejson()
         newdoc.update(columndoc)

--- a/ermrest/model/key.py
+++ b/ermrest/model/key.py
@@ -300,6 +300,58 @@ class PseudoUnique (object):
     def __repr__(self):
         return '<ermrest.model.PseudoUnique %s>' % str(self)
 
+    def update(self, conn, cur, keydoc, ermrest_config):
+        """Idempotently update existing key state on part-by-part basis.
+
+        The parts to update can be made sparse by excluding any of the
+        mutable fields from the input doc:
+
+        - 'names'
+        - 'comment'
+        - 'annotations'
+
+        An absent field will retain its current state from the
+        existing column in the model. To be clear, "absent" means the
+        field key is not present in the input document.
+
+        """
+        # allow sparse update documents as a (not so restful) convenience
+        newdoc = self.prejson()
+        if 'names' not in keydoc \
+           or not keydoc['names'][0:1] \
+           or not keydoc['names'][0][1:2] \
+           or not keydoc['names'][0][1]:
+            del keydoc['names']
+        newdoc.update(keydoc)
+        newdoc['names'][0][0] = self.constraint_name[0]
+        newkey = list(Unique.fromjson_single(self.table, newdoc, reject_duplicates=False))[0]
+        newkey.rid = self.rid
+
+        if self.columns != newkey.columns:
+            raise exception.BadData('Key columns in URL and in JSON must match.')
+
+        if self.comment != newkey.comment:
+            self.set_comment(conn, cur, newkey.comment)
+
+        if self.annotations != newkey.annotations:
+            self.set_annotations(conn, cur, newkey.annotations)
+
+        # key rename cannot be combined with other actions above
+        if self.constraint_name[1] != newkey.constraint_name[1]:
+            cur.execute(
+                """
+SELECT _ermrest.model_version_bump();
+UPDATE _ermrest.known_pseudo_keys e
+SET constraint_name = %(name)s
+WHERE e."RID" = %(rid)s;
+""" % {
+    'rid': sql_literal(self.rid),
+    'name': sql_literal(newkey.constraint_name[1]),
+}
+            )
+
+        return newkey
+
     def enforce_right(self, aclname):
         """Proxy enforce_right to self.table for interface consistency."""
         self.table.enforce_right(aclname)

--- a/ermrest/model/key.py
+++ b/ermrest/model/key.py
@@ -110,6 +110,7 @@ SELECT _ermrest.model_version_bump();
         field key is not present in the input document.
 
         """
+        self.enforce_right('owner')
         # allow sparse update documents as a (not so restful) convenience
         newdoc = self.prejson()
         if 'names' not in keydoc \
@@ -315,6 +316,7 @@ class PseudoUnique (object):
         field key is not present in the input document.
 
         """
+        self.enforce_right('owner')
         # allow sparse update documents as a (not so restful) convenience
         newdoc = self.prejson()
         if 'names' not in keydoc \

--- a/ermrest/model/key.py
+++ b/ermrest/model/key.py
@@ -507,9 +507,9 @@ class ForeignKey (object):
                     return True
         return False
 
-def _guarded_add(s, new_fkr):
+def _guarded_add(s, new_fkr, reject_duplicates=True):
     for fkr in s:
-        if fkr.reference_map_frozen == new_fkr.reference_map_frozen:
+        if fkr.reference_map_frozen == new_fkr.reference_map_frozen and reject_duplicates:
             raise NotImplementedError(
                 'Foreign key constraint %s collides with constraint %s on table %s.' % (
                     new_fkr.constraint_name,
@@ -593,7 +593,7 @@ def _keyref_has_right(self, aclname, roles=None):
 class KeyReference (object):
     """A reference from a foreign key to a primary key."""
     
-    def __init__(self, foreign_key, unique, fk_ref_map, on_delete='NO ACTION', on_update='NO ACTION', constraint_name=None, annotations={}, comment=None, acls={}, dynacls={}, rid=None):
+    def __init__(self, foreign_key, unique, fk_ref_map, on_delete='NO ACTION', on_update='NO ACTION', constraint_name=None, annotations={}, comment=None, acls={}, dynacls={}, rid=None, reject_duplicates=True):
         self.foreign_key = foreign_key
         self.unique = unique
         self.rid = rid
@@ -608,10 +608,10 @@ class KeyReference (object):
         self.constraint_name = constraint_name
         if unique.table not in foreign_key.table_references:
             foreign_key.table_references[unique.table] = set()
-        _guarded_add(foreign_key.table_references[unique.table], self)
+        _guarded_add(foreign_key.table_references[unique.table], self, reject_duplicates=reject_duplicates)
         if foreign_key.table not in unique.table_references:
             unique.table_references[foreign_key.table] = set()
-        _guarded_add(unique.table_references[foreign_key.table], self)
+        _guarded_add(unique.table_references[foreign_key.table], self, reject_duplicates=reject_duplicates)
         self.annotations = AltDict(lambda k: exception.NotFound(u'annotation "%s" on foreign key %s' % (k, self.constraint_name)))
         self.annotations.update(annotations)
         self.acls = AclDict(self)
@@ -717,8 +717,83 @@ RETURNING fkey_rid;
         """Canonicalized to-column names list."""
         return _keyref_to_column_names(self)
         
+    def update(self, conn, cur, refdoc, ermrest_config):
+        """Idempotently update existing fkey state on part-by-part basis.
+
+        The parts to update can be made sparse by excluding any of the
+        mutable fields from the input doc:
+
+        - 'names'
+        - 'comment'
+        - 'acls'
+        - 'acl_bindings'
+        - 'annotations'
+
+        An absent field will retain its current state from the
+        existing column in the model. To be clear, "absent" means the
+        field key is not present in the input document.
+
+        """
+        self.enforce_right('owner')
+        # allow sparse update documents as a (not so restful) convenience
+        newdoc = self.prejson()
+        refdoc = refdoc[0] if isinstance(refdoc, list) else refdoc
+        newdoc.update(refdoc)
+        newfkr = list(KeyReference.fromjson(
+            self.foreign_key.table.schema.model,
+            newdoc,
+            self.foreign_key,
+            self.foreign_key.table,
+            self.unique,
+            self.unique.table,
+            reject_duplicates=False
+        ))[0]
+        newfkr.rid = self.rid
+
+        # undo default ACLs generated in fromjson on acls: {} input...
+        newfkr.acls.clear()
+        if 'acls' in refdoc:
+            newfkr.acls.update(refdoc['acls'])
+        else:
+            newfkr.acls.update(self.acls)
+
+        if self.reference_map_frozen != newfkr.reference_map_frozen:
+            raise exception.BadData('Foreign key column mapping in URL and in JSON must match.')
+
+        if self.comment != newfkr.comment:
+            self.set_comment(conn, cur, newfkr.comment)
+
+        if self.annotations != newfkr.annotations:
+            self.set_annotations(conn, cur, newfkr.annotations)
+
+        if self.acls != newfkr.acls:
+            self.set_acls(cur, newfkr.acls, anon_mutation_ok=True)
+
+        if self.dynacls != newfkr.dynacls:
+            self.set_dynacls(cur, newfkr.dynacls)
+
+        # key rename cannot be combined with other actions above
+        if self.constraint_name[1] != newfkr.constraint_name[1]:
+            self.foreign_key.table.alter_table(
+                conn, cur,
+                'RENAME CONSTRAINT %s TO %s' % (
+                    sql_identifier(self.constraint_name[1]),
+                    sql_identifier(newfkr.constraint_name[1]),
+                ),
+                """
+UPDATE _ermrest.known_fkeys e
+SET constraint_name = %(name)s
+WHERE e."RID" = %(rid)s;
+""" % {
+    'rid': sql_literal(self.rid),
+    'name': sql_literal(newfkr.constraint_name[1]),
+}
+            )
+
+        return newfkr
+
     @staticmethod
-    def fromjson(model, refdoc, fkey=None, fktable=None, pkey=None, pktable=None, outfkeys=None):
+    def fromjson(model, refdoc, fkey=None, fktable=None, pkey=None, pktable=None, outfkeys=None, reject_duplicates=True):
         fk_cols = []
         pk_cols = []
         refs = []
@@ -788,12 +863,12 @@ RETURNING fkey_rid;
                     else:
                         key = table.uniques[colset]
 
-            elif is_fkey and fk_colset != fkey.columns:
+            elif is_fkey and colset != fkey.columns:
                 raise exception.ConflictModel(
                     'Reference map referring columns %s do not match foreign key columns %s.' 
                     % (colset, key.columns)
                     )
-            elif (not is_fkey) and fk_colset != fkey.columns:
+            elif (not is_fkey) and colset != fkey.columns:
                 raise exception.ConflictModel(
                     'Reference map referenced columns %s do not match unique columns %s.' 
                     % (colset, key.columns)
@@ -818,13 +893,13 @@ RETURNING fkey_rid;
         fk_ref_map = frozendict(dict([ (fk_columns[i], pk_columns[i]) for i in range(0, len(fk_columns)) ]))
         fk_name = fk_names[0] if fk_names else None
             
-        if fk_ref_map not in fkey.references:
+        if fk_ref_map not in fkey.references or not reject_duplicates:
             if fktable.kind == 'r' and pktable.kind == 'r':
                 on_delete = check_rule('on_delete')
                 on_update = check_rule('on_update')
-                fkr = KeyReference(fkey, pkey, fk_ref_map, on_delete, on_update, fk_name, annotations, comment, acls, dynacls)
+                fkr = KeyReference(fkey, pkey, fk_ref_map, on_delete, on_update, fk_name, annotations, comment, acls, dynacls, reject_duplicates=reject_duplicates)
             else:
-                fkr = PseudoKeyReference(fkey, pkey, fk_ref_map, None, fk_name, annotations, comment, acls, dynacls)
+                fkr = PseudoKeyReference(fkey, pkey, fk_ref_map, None, fk_name, annotations, comment, acls, dynacls, reject_duplicates=reject_duplicates)
             fkey.references[fk_ref_map] = fkr
         else:
             raise exception.ConflictModel("Foreign key %s already exists from table %s to %s with reference mapping %s." % (
@@ -862,7 +937,7 @@ RETURNING fkey_rid;
 class PseudoKeyReference (object):
     """A psuedo-reference from a foreign key to a primary key."""
     
-    def __init__(self, foreign_key, unique, fk_ref_map, rid=None, constraint_name=("", None), annotations={}, comment=None, acls={}, dynacls={}):
+    def __init__(self, foreign_key, unique, fk_ref_map, rid=None, constraint_name=("", None), annotations={}, comment=None, acls={}, dynacls={}, reject_duplicates=True):
         self.foreign_key = foreign_key
         self.unique = unique
         self.reference_map_frozen = fk_ref_map
@@ -919,6 +994,76 @@ SELECT _ermrest.model_version_bump();
 
     def __repr__(self):
         return '<ermrest.model.KeyReference %s>' % str(self)
+
+    def update(self, conn, cur, refdoc, ermrest_config):
+        """Idempotently update existing fkey state on part-by-part basis.
+
+        The parts to update can be made sparse by excluding any of the
+        mutable fields from the input doc:
+
+        - 'names'
+        - 'comment'
+        - 'acls'
+        - 'acl_bindings'
+        - 'annotations'
+
+        An absent field will retain its current state from the
+        existing column in the model. To be clear, "absent" means the
+        field key is not present in the input document.
+
+        """
+        self.enforce_right('owner')
+        # allow sparse update documents as a (not so restful) convenience
+        newdoc = self.prejson()
+        refdoc = refdoc[0] if isinstance(refdoc, list) else refdoc
+        newdoc.update(refdoc)
+        newfkr = list(KeyReference.fromjson(
+            self.foreign_key.table.schema.model,
+            newdoc,
+            self.foreign_key,
+            self.foreign_key.table,
+            self.unique,
+            self.unique.table,
+            reject_duplicates=False
+        ))[0]
+        newfkr.rid = self.rid
+
+        # undo default ACLs generated in fromjson on acls: {} input...
+        newfkr.acls.clear()
+        if 'acls' in refdoc:
+            newfkr.acls.update(refdoc['acls'])
+        else:
+            newfkr.acls.update(self.acls)
+
+        if self.reference_map_frozen != newfkr.reference_map_frozen:
+            raise exception.BadData('Foreign key column mapping in URL and in JSON must match.')
+
+        if self.comment != newfkr.comment:
+            self.set_comment(conn, cur, newfkr.comment)
+
+        if self.annotations != newfkr.annotations:
+            self.set_annotations(conn, cur, newfkr.annotations)
+
+        if self.acls != newfkr.acls:
+            self.set_acls(cur, newfkr.acls, anon_mutation_ok=True)
+
+        if self.dynacls != newfkr.dynacls:
+            self.set_dynacls(cur, newfkr.dynacls)
+
+        # key rename cannot be combined with other actions above
+        if self.constraint_name[1] != newfkr.constraint_name[1]:
+            cur.execute("""
+SELECT _ermrest.model_version_bump();
+UPDATE _ermrest.known_pseudo_fkeys e
+SET constraint_name = %(name)s
+WHERE e."RID" = %(rid)s;
+""" % {
+    'rid': sql_literal(self.rid),
+    'name': sql_literal(newfkr.constraint_name[1]),
+}
+            )
+
+        return newfkr
 
     def add(self, conn, cur):
         self.foreign_key.table.enforce_right('owner') # since we don't use alter_table which enforces for real keyrefs

--- a/ermrest/model/schema.py
+++ b/ermrest/model/schema.py
@@ -202,6 +202,7 @@ class Schema (object):
         aspect to reach that state.
 
         """
+        self.enforce_right('owner')
         newschema = Schema(
             self.model,
             schemadoc.get('schema_name', self.name),

--- a/ermrest/model/table.py
+++ b/ermrest/model/table.py
@@ -156,6 +156,84 @@ class Table (object):
     def verbose(self):
         return json.dumps(self.prejson(), indent=2)
 
+    def update(self, conn, cur, tabledoc, ermrest_config):
+        """Idempotently update existing table state on part-by-part basis.
+
+        The parts to update can be made sparse by excluding any of the
+        mutable fields from the input tabledoc:
+
+        - 'schema_name'
+        - 'table_name'
+        - 'comment'
+        - 'acls'
+        - 'acl_bindings'
+        - 'annotations'
+
+        An absent field will retain its current state from the
+        existing table in the model. To be clear, "absent" means the
+        field key is not present in the input document. Presence with
+        an empty value such as `"acls": {}` will mutate the model
+        aspect to reach that state.
+
+        """
+        newtable = Table(
+            self.schema,
+            tabledoc.get('table_name', self.name),
+            [],
+            self.kind,
+            tabledoc.get('comment', self.comment),
+            tabledoc.get('annotations', self.annotations),
+            tabledoc.get('acls', self.acls),
+            tabledoc.get('acl_bindings', self.dynacls),
+            self.rid,
+        )
+
+        if self.comment != newtable.comment:
+            self.set_comment(conn, cur, newtable.comment)
+
+        if self.annotations != newtable.annotations:
+            self.set_annotations(conn, cur, newtable.annotations)
+
+        if self.acls != newtable.acls:
+            self.set_acls(cur, newtable.acls)
+
+        if self.dynacls != newtable.dynacls:
+            self.set_dynacls(cur, newtable.dynacls)
+
+        if self.name != newtable.name:
+            self.alter_table(
+                conn, cur,
+                'RENAME TO %s' % (sql_identifier(newtable.name),),
+                """
+UPDATE _ermrest.known_tables e
+SET table_name = %(tname)s
+WHERE e."RID" = %(rid)s;
+""" % {
+    'rid': sql_literal(self.rid),
+    'tname': sql_literal(newtable.name),
+}
+            )
+
+        if 'schema_name' in tabledoc and str(self.schema.name) != tabledoc['schema_name']:
+            newschema = self.schema.model.schemas.get_enumerable(tabledoc['schema_name'])
+            newtable.alter_table(
+                conn, cur,
+                'SET SCHEMA %s' % (sql_identifier(newschema.name),),
+                """
+UPDATE _ermrest.known_tables e
+SET schema_rid = %(srid)s
+WHERE e."RID" = %(trid)s;
+""" % {
+    'trid': sql_literal(self.rid),
+    'srid': sql_literal(newschema.rid),
+}
+            )
+            newtable.schema = newschema
+
+        for c in self.columns_in_order():
+            newtable.columns[c.name] = c
+        return newtable
+
     @staticmethod
     def create_fromjson(conn, cur, schema, tabledoc, ermrest_config):
         sname = tabledoc.get('schema_name', schema.name)

--- a/ermrest/model/table.py
+++ b/ermrest/model/table.py
@@ -249,6 +249,7 @@ WHERE e.fk_table_rid = %(trid)s;
         newtable.fkeys = self.fkeys
         for c in self.columns_in_order():
             newtable.columns[c.name] = c
+            c.table = newtable
 
         return newtable
 

--- a/ermrest/model/table.py
+++ b/ermrest/model/table.py
@@ -176,6 +176,7 @@ class Table (object):
         aspect to reach that state.
 
         """
+        self.enforce_right('owner')
         newtable = Table(
             self.schema,
             tabledoc.get('table_name', self.name),

--- a/ermrest/url/ast/model.py
+++ b/ermrest/url/ast/model.py
@@ -772,11 +772,7 @@ class Column (Api):
         try:
             # handle alteration of existing column
             column = table.columns.get_enumerable(self.name.one_str())
-            update = self.queryopts.get('update')
-            if isinstance(update, str):
-                # promote single field name from URL to set of field names
-                update = set([update])
-            return column.update(conn, cur, columndoc, web.ctx.ermrest_config, update)
+            return column.update(conn, cur, columndoc, web.ctx.ermrest_config)
         except exception.ConflictModel as e:
             # handle creation of new column, same as POST /column/
             columns = Columns(self.table)


### PR DESCRIPTION
This PR adds model alteration via the PUT method on the model node to be altered. (The PUT method previously responses with the No Method error response.)

This feature allows alteration of several aspects of the model elements currently represented as fields within the JSON representation of the model node:

- Schema: schema\_name, comment, acls, annotations
- Table: schema\_name, table\_name, comment, acls, acl\_bindings, annotations
- Column: name, type, default, nullok, comment, acls, acl\_bindings, annotations
- Key: names, comment, annotations
- Foreign Key: names, comment, acls, acl\_bindings, annotations

When the fields are _present_ in the PUT input and _different_ from the existing configuration of the model node, the model is altered to match those new configurations. However, if a field is completely _absent_ from the input, it is left unchanged in the existing model node.  Presence with value `null` is a distinct state from absence of the field.

However, the major nested components of the model hierarchy cannot be altered by this interface. These nesting fields are ignored if present in input:
- Schema: tables
- Table: column\_definitions, keys, foreign\_keys

Hence, to alter a model node, the client must use the PUT method specifically on that node. To remove a nested node, the client must use the DELETE method specifically on that node. To add a new nested node, the clietn must use POST on the specific nesting container resource (e.g. `/schema/S1/table/` to create a new table in schema S1).

