### PR TITLE
fix for invalid SQL generated for history access with acl b…

### DIFF
--- a/ermrest/ermpath/resource.py
+++ b/ermrest/ermpath/resource.py
@@ -1759,9 +1759,9 @@ class EntityPath (AnyPath):
         context_pos = self.current_entity_position()
 
         if selects is None:
-            # non-enumerable columns will be omitted from entity results
-            for col in context_table.columns_in_order():
-                if enforce_client:
+            # non-enumerable columns will be omitted from entity results when enforcing
+            if enforce_client:
+                for col in context_table.columns_in_order(enforce_client=enforce_client):
                     col.enforce_data_right('select')
             selects = ", ".join([
                 "%st%d.%s" % (prefix, context_pos, sql_identifier(col.name))

--- a/ermrest/model/table.py
+++ b/ermrest/model/table.py
@@ -116,8 +116,8 @@ class Table (object):
                 return False
         return self._has_right(aclname, roles)
 
-    def columns_in_order(self):
-        cols = [ c for c in self.columns.values() if c.has_right('enumerate') ]
+    def columns_in_order(self, enforce_client=True):
+        cols = [ c for c in self.columns.values() if c.has_right('enumerate') or not enforce_client ]
         cols.sort(key=lambda c: c.position)
         return cols
 
@@ -557,7 +557,7 @@ WHERE "RID" = %s;
 """ % {
     'projs': ','.join([
         c.type.history_projection(c)
-        for c in self.columns_in_order()
+        for c in self.columns_in_order(enforce_client=False)
     ]),
     'htable': "_ermrest_history.%s" % sql_identifier("t%s" % self.rid),
     'when': sql_literal(web.ctx.ermrest_history_snaptime),


### PR DESCRIPTION
…indings over non-enumerable columns

The query generator for acl bindings can access non-enumerable columns
of live tables to support policies involving content hidden from the
calling client.

However, the snapshot query generator replaces live tables with a
subquery projecting content from the per-table history storage. This
projection only included enumerable columns, so the compiled policy
terms can reference columns that are not present in the subquery.

The fix is to turn off enumerability-checks when generating the
projection list in these table snapshot subqueries.