### PR TITLE
add POST /entity/tablename?onconflict=skip for idempotent insert

### DIFF
--- a/docs/api-doc/data/naming.md
+++ b/docs/api-doc/data/naming.md
@@ -22,6 +22,7 @@ where the components in this structure are:
    - the `limit` parameter to define query result paging length
    - the `accept` parameter to override HTTP `Accept` header for content negotiation
    - the `defaults` and `nondefaults` parameters to modify the behavior of POST operations to the `entity` API
+   - the `onconflict` paramter to modify the behavior of POST operations to the `entity` API
 
 ## Entity Resolution Names
 
@@ -454,6 +455,16 @@ An optional `nondefaults` query parameter can be used with the `POST` operation 
 - _service_ `/catalog/` _cid_ `/entity/` _schema name_ `:` _table name_ `?nondefaults=` _column name_ `,` ...
 
 A list of one or more _column name_ indicates columns of the target table which should be populated using client-supplied values, overriding an implicit default behavior. This is primarily useful for administrative clients who are copying table data including existing `RID` values from one table or catalog to another. See the [Entity Creation with Defaults](rest.md#entity-creation-with-defaults) operation documentation for more explanation.
+
+## Onconflict Query Parameter
+
+An optional `onconflict` query parameter can be used with the `POST` operation on the `entity` API:
+
+- _service_ `/catalog/` _cid_ `/entity/` _schema name_ `:` _table name_ `?onconflict=` _action_
+
+An action name specifies behavior when an input row matches an existing row in named table:
+- `skip`: discard the input row as a presumed idempotent duplicate
+- `abort`: abort the request on this collision of unique keys (default)
 
 ## Limit Query Parameter
 

--- a/docs/api-doc/data/rest.md
+++ b/docs/api-doc/data/rest.md
@@ -137,6 +137,19 @@ Typical error response codes include:
 - 403 Forbidden
 - 401 Unauthorized
 
+### Idempotent Entity Creation
+
+The POST operation is also used to create new entity records unless they already exist, using an entity resource data name of the form:
+
+- _service_ `/catalog/` _cid_ `/entity/` _table name_ `?onconflict=skip`
+- _service_ `/catalog/` _cid_ `/entity/` _schema name_ `:` _table name_ `?onconflict=skip`
+- _service_ `/catalog/` _cid_ `/entity/` _table name_ `?defaults=` _column name_ `&onconflict=skip`
+
+In this request variant, input rows with keys matching existing data are presumed to be redundant and are discarded. No attempt is made to
+compare or preserve non-key material from the discarded inputs. This `onconflict=skip` behavior may be mixed with the other `defaults` and `nondefaults` query parameters described previously.
+
+The input and output are identical to previous descriptions, except that discarded input rows will not be represented in the response.
+
 ## Entity Update
 
 The PUT operation is used to update entity records in a table, using an `entity` resource data name of the form:

--- a/docs/api-doc/index.md
+++ b/docs/api-doc/index.md
@@ -190,6 +190,7 @@ The [data resources](data/naming.md) make use of a model-driven language for den
 1. [Download Query Parameter](data/naming.md#download-query-parameter)
 1. [Defaults Query Parameter](data/naming.md#defaults-query-parameter)
 1. [Nondefaults Query Parameter](data/naming.md#nondefaults-query-parameter)
+1. [Onconflict Query Parameter](data/naming.md#onconflict-query-parameter)
 1. [Limit Query Parameter](data/naming.md#limit-query-parameter)
 
 The sort, paging, and limit syntax together can support [paged data access](data/naming.md#data-paging).

--- a/ermrest/ermpath/resource.py
+++ b/ermrest/ermpath/resource.py
@@ -1184,7 +1184,7 @@ class EntityElem (object):
         results1.extend(results2)
         return results1
 
-    def insert(self, conn, cur, input_data, in_content_type='text/csv', content_type='text/csv', output_file=None, use_defaults=None, non_defaults=None):
+    def insert(self, conn, cur, input_data, in_content_type='text/csv', content_type='text/csv', output_file=None, use_defaults=None, non_defaults=None, only_nonmatch=False):
         """Insert entities.
 
            conn: sanepg2 connection to catalog
@@ -1229,6 +1229,9 @@ class EntityElem (object):
            non_defaults: customize entity processing
               { col, ... } --> use input data for zero or more columns
               None --> same as empty set
+
+           only_nonmatch: customize entity processing
+              skip input rows that collide with existing row
 
            If a column is named in both use_defaults and non_defaults,
            the latter takes precedence. In practice, the non_defaults
@@ -1326,7 +1329,8 @@ class EntityElem (object):
                 mkcol_aliases, nmkcol_aliases,
                 content_type,
                 use_defaults,
-                extra_return_cols
+                extra_return_cols,
+                only_nonmatch=only_nonmatch
             )
 
             for table in drop_tables:
@@ -1959,7 +1963,7 @@ WHERE %(keymatches)s
 
         return self._path[0].upsert(conn, cur, input_data, in_content_type, content_type, output_file)
 
-    def insert(self, conn, cur, input_data, in_content_type='text/csv', content_type='text/csv', output_file=None, use_defaults=None, non_defaults=None):
+    def insert(self, conn, cur, input_data, in_content_type='text/csv', content_type='text/csv', output_file=None, use_defaults=None, non_defaults=None, only_nonmatch=False):
         """Insert entities.
 
            conn: sanepg2 connection to catalog
@@ -2001,7 +2005,7 @@ WHERE %(keymatches)s
         if len(self._path) != 1:
             raise BadData("unsupported path length for insertion")
 
-        return self._path[0].insert(conn, cur, input_data, in_content_type, content_type, output_file, use_defaults, non_defaults)
+        return self._path[0].insert(conn, cur, input_data, in_content_type, content_type, output_file, use_defaults, non_defaults, only_nonmatch=only_nonmatch)
 
     def update(self, conn, cur, input_data, in_content_type='text/csv', content_type='text/csv', output_file=None, attr_update=None, attr_aliases=None):
         """Update entities.

--- a/ermrest/url/ast/data/__init__.py
+++ b/ermrest/url/ast/data/__init__.py
@@ -288,7 +288,14 @@ class Entity (Api):
                 defaults = set()
             # defaults is always a set at this point
             return defaults
-        return _PUT(self, uri, lambda args: self.epath.insert(*args, use_defaults=prepare_defaults('defaults'), non_defaults=prepare_defaults('nondefaults')), self.epath)
+        onconflict = self.queryopts.get('onconflict', 'abort').lower()
+        if onconflict == 'skip':
+            only_nonmatch = True
+        elif onconflict == 'abort':
+            only_nonmatch = False
+        else:
+            raise exception.BadSyntax('Unknown action name in query parameter onconflict="%s". Expected "skip" or "abort".' % onconflict)
+        return _PUT(self, uri, lambda args: self.epath.insert(*args, use_defaults=prepare_defaults('defaults'), non_defaults=prepare_defaults('nondefaults'), only_nonmatch=only_nonmatch), self.epath)
 
     def DELETE(self, uri):
         """Perform HTTP DELETE of entities.


### PR DESCRIPTION
This only supports the easiest scenario, but in a way that could
potentially be enhanced with more sub-options later. It uses the
existing "metakey" mechanism to distinguish colliding rows and simply
discards them.

This results in a first-writer-wins strategy for inserting rows only
if missing, but not attempting mix any update semantics into the
existing insert operation.