### PR TITLE
add magic tag:isrd.isi.edu,2020:history-capture annotation for tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 dist: focal
 
 python:
-  - "3.7"
+  - "3.8"
 
 virtualenv:
   system_site_packages: true
@@ -19,9 +19,9 @@ addons:
     packages:
       - libpq-dev
       - libjson-c-dev
-      - postgresql-11
-      - postgresql-client-11
-      - postgresql-server-dev-11
+      - postgresql-12
+      - postgresql-client-12
+      - postgresql-server-dev-12
       - apache2
       - apache2-dev
       - ssl-cert
@@ -40,11 +40,11 @@ env:
 
 before_install:
   - sudo mount -o remount,size=50% /var/ramfs
-  - sudo su -c 'echo /usr/lib/python3.7/site-packages > /usr/local/lib/python3.7/dist-packages/sys-site-packages.pth'
+  - sudo su -c 'echo /usr/lib/python3.8/site-packages > /usr/local/lib/python3.8/dist-packages/sys-site-packages.pth'
   - sudo ln -s /etc/apache2/conf-enabled /etc/apache2/conf.d
   - sudo service postgresql stop
   - sudo apt-get -y purge postgresql-9.1 postgresql-9.2 postgresql-9.3 postgresql-9.4 postgresql-9.5 postgresql-9.6
-  - sudo service postgresql start 11
+  - sudo service postgresql start 12
   - sudo -H -u postgres psql -c "SHOW ALL"
   - sudo a2enmod ssl
   - sudo a2ensite default-ssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ before_install:
   - sudo su -c 'echo /usr/lib/python3.8/site-packages > /usr/local/lib/python3.8/dist-packages/sys-site-packages.pth'
   - sudo ln -s /etc/apache2/conf-enabled /etc/apache2/conf.d
   - sudo service postgresql stop
-  - sudo apt-get -y purge postgresql-9.1 postgresql-9.2 postgresql-9.3 postgresql-9.4 postgresql-9.5 postgresql-9.6
   - sudo service postgresql start 12
   - sudo -H -u postgres psql -c "SHOW ALL"
   - sudo a2enmod ssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ before_install:
 install:
   - sudo make install PLATFORM=ubuntu1604
   - sudo make deploy PLATFORM=ubuntu1604
+  - sudo bash ./test/ubuntu-travis-setup.sh
   - sudo service apache2 restart
 
 before_script:
@@ -96,4 +97,3 @@ after_failure:
   - sudo -H -u postgres psql -c '\dn' _ermrest_catalog_5
   - sudo cat /etc/apache2/sites-available/000-default.conf
   - sudo cat /etc/apache2/sites-available/default-ssl.conf
-  - sudo cat /etc/apache2/sites-available/default-ssl.conf.orig

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@
 language: python
 
 sudo: required
-dist: xenial
+dist: bionic
 
 python:
-  - "3.7"
+  - "3.6"
 
 virtualenv:
   system_site_packages: true
@@ -40,7 +40,7 @@ env:
 
 before_install:
   - sudo mount -o remount,size=50% /var/ramfs
-  - sudo su -c 'echo /usr/lib/python3.7/site-packages > /usr/local/lib/python3.7/dist-packages/sys-site-packages.pth'
+  - sudo su -c 'echo /usr/lib/python3.6/site-packages > /usr/local/lib/python3.6/dist-packages/sys-site-packages.pth'
   - sudo ln -s /etc/apache2/conf-enabled /etc/apache2/conf.d
   - sudo service postgresql stop
   - sudo apt-get -y purge postgresql-9.1 postgresql-9.2 postgresql-9.3 postgresql-9.4 postgresql-9.5 postgresql-9.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 dist: bionic
 
 python:
-  - "3.6"
+  - "3.7"
 
 virtualenv:
   system_site_packages: true
@@ -40,7 +40,7 @@ env:
 
 before_install:
   - sudo mount -o remount,size=50% /var/ramfs
-  - sudo su -c 'echo /usr/lib/python3.6/site-packages > /usr/local/lib/python3.6/dist-packages/sys-site-packages.pth'
+  - sudo su -c 'echo /usr/lib/python3.7/site-packages > /usr/local/lib/python3.7/dist-packages/sys-site-packages.pth'
   - sudo ln -s /etc/apache2/conf-enabled /etc/apache2/conf.d
   - sudo service postgresql stop
   - sudo apt-get -y purge postgresql-9.1 postgresql-9.2 postgresql-9.3 postgresql-9.4 postgresql-9.5 postgresql-9.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 dist: xenial
 
 python:
-  - "3.5"
+  - "3.7"
 
 virtualenv:
   system_site_packages: true
@@ -40,7 +40,7 @@ env:
 
 before_install:
   - sudo mount -o remount,size=50% /var/ramfs
-  - sudo su -c 'echo /usr/lib/python3.5/site-packages > /usr/local/lib/python3.5/dist-packages/sys-site-packages.pth'
+  - sudo su -c 'echo /usr/lib/python3.7/site-packages > /usr/local/lib/python3.7/dist-packages/sys-site-packages.pth'
   - sudo ln -s /etc/apache2/conf-enabled /etc/apache2/conf.d
   - sudo service postgresql stop
   - sudo apt-get -y purge postgresql-9.1 postgresql-9.2 postgresql-9.3 postgresql-9.4 postgresql-9.5 postgresql-9.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: python
 
 sudo: required
-dist: bionic
+dist: focal
 
 python:
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ addons:
     packages:
       - libpq-dev
       - libjson-c-dev
-      - postgresql-10
-      - postgresql-client-10
-      - postgresql-server-dev-10
+      - postgresql-11
+      - postgresql-client-11
+      - postgresql-server-dev-11
       - apache2
       - apache2-dev
       - ssl-cert
@@ -44,7 +44,7 @@ before_install:
   - sudo ln -s /etc/apache2/conf-enabled /etc/apache2/conf.d
   - sudo service postgresql stop
   - sudo apt-get -y purge postgresql-9.1 postgresql-9.2 postgresql-9.3 postgresql-9.4 postgresql-9.5 postgresql-9.6
-  - sudo service postgresql start 10
+  - sudo service postgresql start 11
   - sudo -H -u postgres psql -c "SHOW ALL"
   - sudo a2enmod ssl
   - sudo a2ensite default-ssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,3 +93,4 @@ after_failure:
   - sudo cat /etc/apache2/conf.d/wsgi_ermrest.conf
   - sudo cat install-record.txt
   - sudo cat ${HTTPD_ERROR_LOG}
+  - sudo -H -u postgres psql -c '\dn' _ermrest_catalog_5

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,3 +94,6 @@ after_failure:
   - sudo cat install-record.txt
   - sudo cat ${HTTPD_ERROR_LOG}
   - sudo -H -u postgres psql -c '\dn' _ermrest_catalog_5
+  - sudo cat /etc/apache2/sites-available/000-default.conf
+  - sudo cat /etc/apache2/sites-available/default-ssl.conf
+  - sudo cat /etc/apache2/sites-available/default-ssl.conf.orig

--- a/docs/api-doc/history/rest.md
+++ b/docs/api-doc/history/rest.md
@@ -158,3 +158,35 @@ may be considered in future enhancements to ERMrest. This syntax is
 sufficient to target one row by its actual `RID` or all rows with a
 certain *bad value* _X_ in the column being redacted.
 
+## Suppress Table History Collection
+
+A special table-level annotation can be supplied during table creation
+or set on an existing table to suppress the collection of row content
+history. Set the annotation URI
+`tag:isrd.isi.edu:2020,history-capture` with one of these annotation
+values to control per-table history capture:
+
+- `false`: Disable history capture and make the table invisible in versioned catalog snapshots
+- `true`: Enable normal history capture and make the table visible in versioned catalog snapshots
+
+In the absence of this annotation, the default behavior of ERMrest is
+the same as if this annotation where set with the value `true`.  Any
+other value besides the JSON boolean values may produce undefined
+behavior and is reserved for future use.
+
+A table which is created with history-capture disabled will avoid the
+storage and write operation overhead of maintaining history.
+
+If the history-capture mechanism is disabled during the table's
+lifecycle, prior history is retained but the history is not captured
+on subsequent writes to the live table content. Prior versions of the
+table are still visible in older snapshots, but the table is invisible
+in catalog snapshots beginning with the one where the history capture
+is disabled.
+
+If the history-capture mechanism is enabled during the table's
+lifecycle, the current state of the table is interred into history and
+collection resumes for subsequent writes to the live table
+content. The table remains invisible in older catalog snapshots, but
+new versions of the table become visible in catalog snapshots
+beginning with the one where history capture is enabled.

--- a/docs/api-doc/rest-catalog.md
+++ b/docs/api-doc/rest-catalog.md
@@ -42,8 +42,28 @@ On success, this request yields a description:
       "annotations": {
         "tag:isrd.isi.edu,2018:example": {"value": "my example annotation"}
       },
-      "snaptime": "2PX-WS30-E58W"
+      "snaptime": "2PX-WS30-E58W",
+      "features": {
+         ...
+      }
     }
+
+The `"features"` field is where ERMrest may advertise software
+features added in subsequent revisions. This allows fine-grained
+feature detection by clients concerned with exploiting new features,
+when available, but falling back to simpler access modes if accessing
+older catalogs.
+
+Known feature flags at time of writing of this document:
+
+- `history_control`: Service supports `tag:isrd.isi.edu:2020,history-capture` table annotation to disable history capture.
+
+Generally, absence of a feature flag means the service is running
+older software which predates the release of the feature. A flag will
+be present with boolean value `true` to advertise presence of a
+feature. Specific flags may be documented with other advertisement
+values in the future, i.e. to indicate runtime status of a feature
+which can be disabled selectively by the administrator.
 
 Typical error response codes include:
 - 404 Not Found

--- a/ermrest/model/schema.py
+++ b/ermrest/model/schema.py
@@ -63,6 +63,9 @@ class Model (object):
             "snaptime": snaptime,
             "annotations": self.annotations,
             "rights": self.rights(),
+            "features": {
+                "history_control": True,
+            },
         }
         if not brief:
             doc["schemas"] = {

--- a/ermrest/model/table.py
+++ b/ermrest/model/table.py
@@ -58,6 +58,7 @@ class Table (object):
     also has a reference to its 'schema'.
     """
     tag_indexing_preferences = 'tag:isrd.isi.edu,2018:indexing-preferences'
+    tag_history_capture = 'tag:isrd.isi.edu,2020:history-capture'
     
     def __init__(self, schema, name, columns, kind, comment=None, annotations={}, acls={}, dynacls={}, rid=None):
         self.schema = schema
@@ -113,6 +114,8 @@ class Table (object):
         # a table without history is not enumerable during historical access
         if web.ctx.ermrest_history_snaptime is not None:
             if not table_exists(web.ctx.ermrest_catalog_pc.cur, '_ermrest_history', 't%s' % self.rid):
+                return False
+            if self.annotations.get(self.tag_history_capture, True) is False:
                 return False
         return self._has_right(aclname, roles)
 

--- a/ermrest/url/ast/history.py
+++ b/ermrest/url/ast/history.py
@@ -600,6 +600,8 @@ def _amend_annotation(cur, h_from, h_until, restype, rid, contentmap):
     for name, content in contentmap.items():
         if not isinstance(name, str):
             raise exception.rest.Conflict('Annotation keys must be textual.')
+        if name in {Table.tag_history_capture}:
+            raise exception.rest.BadRequest('Annotations with key %s cannot be amended.' % name)
 
     _amend_config(cur, h_from, h_until, restype, 'annotation', rid, 'annotation_uri', 'annotation_value', contentmap)
 

--- a/test/resttest/history.py
+++ b/test/resttest/history.py
@@ -254,6 +254,8 @@ def _add_history_probes(klass):
     for ridkey in ['catalog', 'schema', 'table', 'ridcol', 'namecol', 'key', 'fkey']:
         _add_bad_amendment(1, 'annotation', ridkey, "not an annotations object")
 
+    _add_bad_amendment(1, 'annotation', 'table', {'tag:isrd.isi.edu,2020:history-capture': False})
+
     for ridkey in ['catalog', 'schema', 'table', 'ridcol', 'namecol', 'fkey']:
         _add_conflict_amendment(1, 'acl', ridkey, {"nonacl": []})
 

--- a/test/resttest/history.py
+++ b/test/resttest/history.py
@@ -4,11 +4,12 @@ import common
 from common import catalog_initial_version, primary_client_id, urlquote, SchemaDoc, ColumnDoc, Int8
 import basics
 import data
-from data import _T1, _T2, _Tc1, _T2b
+from data import _T0, _T1, _T2, _Tc1, _T2b
 import json
 
 _S = 'history_read'
 _defs = basics.defs(_S)
+_defs['schemas'][_S]['tables'][_T0]['annotations'] = { 'tag:isrd.isi.edu,2020:history-capture': False }
 _table_defs = _defs['schemas'][_S]['tables']
 _model = None
 
@@ -29,6 +30,7 @@ def setUpModule():
     if r.status_code == 404:
         # idempotent because unittest can re-enter module several times...
         common.primary_session.post('schema', json=_defs).raise_for_status()
+        common.primary_session.post('entity/%s:%s' % (_S, _T0), json=data.Minimal._initial).raise_for_status()
         common.primary_session.post('entity/%s:%s' % (_S, _T1), json=data.BasicKey._initial).raise_for_status()
         common.primary_session.post('entity/%s:%s' % (_S, _T2), json=data.ForeignKey.data).raise_for_status()
         _data_t0_version = common.primary_session.get('').json()['snaptime']
@@ -39,6 +41,7 @@ def setUpModule():
         common.primary_session.delete('entity/%s:%s' % (_S, _T2)).raise_for_status()
         _data_t3_version = common.primary_session.get('').json()['snaptime']
         common.primary_session.delete('entity/%s:%s' % (_S, _T1)).raise_for_status()
+        common.primary_session.put('schema/%s/table/%s/annotation' % (_S, _T0), json={}).raise_for_status()
         _data_t4_version = common.primary_session.get('').json()['snaptime']
         r = common.primary_session.get('schema')
         r.raise_for_status()
@@ -109,6 +112,7 @@ class ModelWhen (CatalogWhen):
         self.assertHttp(self.session.post((catalog_initial_version, self.container_resource), json=[]), 403)
 
 class TableWhen (common.ErmrestTest):
+    _entity_T0 = 'entity/%s:%s' % (_S, _T0)
     _entity_T1 = 'entity/%s:%s' % (_S, _T1)
     _entity_T2 = 'entity/%s:%s' % (_S, _T2)
 
@@ -182,6 +186,12 @@ class TableWhen (common.ErmrestTest):
 
     def test_schema_not_found(self):
         self.assertHttp(self.session.get((catalog_initial_version, 'entity/%s:%s' % (_S, _T1))), 409)
+
+    def test_t0_no_history(self):
+        self.assertHttp(self.session.get((_data_t0_version, 'schema/%s/table/%s' % (_S, _T0))), 404)
+
+    def test_t0_enabled_history(self):
+        self._test_numrows(_data_t4_version, self._entity_T0, 2)
 
 def _add_history_probes(klass):
     ridfuncs = {

--- a/test/ubuntu-travis-setup.sh
+++ b/test/ubuntu-travis-setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+# monkey with ssl.conf for travisci (ubuntu) tests
+
+conf=/etc/apache2/sites-available/default-ssl.conf
+pattern="^\([[:space:]]*\)\(ServerAdmin .*\)"
+replacement="\1\2"
+replacement+="\1\n# ermrest needs this for full test suite"
+replacement+="\1\nAllowEncodedSlashes On"
+
+mv -f $conf $conf.orig
+sed -e "s|$pattern|$replacement|" \
+    < $conf.orig \
+    > $conf
+chmod u+rw,og=r $conf
+


### PR DESCRIPTION
Setting a table-level annotation with key `tag:isrd.isi.edu,2020:history-capture` to JSON `false` will disable history capture. Setting to JSON `true` is same as removing the annotation and produces default history behavior of ERMrest.  This hint is secondary to other ERMrest rules and so is irrelevant if ERMrest has already decided to disable history, i.e. due to absence of required system columns or because the table kind is a view or other unusual relation in PostgresSQL.

This feature is announced in the newy added `"features"` sub-document of the catalog descrption as the `"history_control"` feature.