### PR TITLE
Stable compound keys

### DIFF
--- a/docs/api-doc/rest-catalog.md
+++ b/docs/api-doc/rest-catalog.md
@@ -38,6 +38,7 @@ if accessing older catalogs.
 Known feature flags at time of writing of this document:
 
 - `history_control`: Service supports `tag:isrd.isi.edu:2020,history-capture` table annotation to disable history capture.
+- `implicit_fkey_index`: Service will produce indexes for compound foreign keys to allow index-based joins on these reference patterns.
 
 Generally, absence of a feature flag means the service is running
 older software which predates the release of the feature. A flag will

--- a/ermrest/model/introspect.py
+++ b/ermrest/model/introspect.py
@@ -220,7 +220,7 @@ SELECT _ermrest.model_version_bump();
             raise ValueError('Foreign key constraint %s has mismatched column list lengths.' % constraint_name)
 
         fk_colset = frozenset(fk_cols)
-        pk_colset = OrderedFrozenSet(pk_cols)
+        pk_colset = frozenset(pk_cols)
         fk_ref_map = frozendict({
             fk_col: pk_col
             for fk_col, pk_col in zip(fk_cols, pk_cols)

--- a/ermrest/model/introspect.py
+++ b/ermrest/model/introspect.py
@@ -220,7 +220,7 @@ SELECT _ermrest.model_version_bump();
             raise ValueError('Foreign key constraint %s has mismatched column list lengths.' % constraint_name)
 
         fk_colset = frozenset(fk_cols)
-        pk_colset = frozenset(pk_cols)
+        pk_colset = OrderedFrozenSet(pk_cols)
         fk_ref_map = frozendict({
             fk_col: pk_col
             for fk_col, pk_col in zip(fk_cols, pk_cols)

--- a/ermrest/model/introspect.py
+++ b/ermrest/model/introspect.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2017 University of Southern California
+# Copyright 2013-2021 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ needed by other modules of the ermrest project.
 import web
 
 from .. import exception
-from ..util import table_exists, view_exists, column_exists, sql_literal, sql_identifier
+from ..util import table_exists, view_exists, column_exists, sql_literal, sql_identifier, OrderedFrozenSet
 from .misc import frozendict, annotatable_classes, hasacls_classes, hasdynacls_classes, AclBinding, current_model_snaptime
 from .schema import Model, Schema
 from .type import TypesEngine
@@ -149,7 +149,7 @@ ORDER BY array_element_type_rid NULLS FIRST, domain_element_type_rid NULLS FIRST
         except KeyError:
             return
 
-        pk_colset = frozenset(pk_cols)
+        pk_colset = OrderedFrozenSet(pk_cols)
 
         # each constraint implies a pkey but might be duplicate
         pk = pk_factory(pk_colset)

--- a/ermrest/model/key.py
+++ b/ermrest/model/key.py
@@ -695,9 +695,7 @@ SELECT _ermrest.model_version_bump();
         self.foreign_key.table.alter_table(
             conn, cur,
             'ADD %s' % self.sql_def(),
-            """
-CREATE INDEX IF NOT EXISTS %(idx_name)s ON %(schema_name)s.%(table_name)s (%(idx_cols)s);
-
+            (('CREATE INDEX IF NOT EXISTS %(idx_name)s ON %(schema_name)s.%(table_name)s (%(idx_cols)s);' if len(fk_cols) > 1 else '') + """
 INSERT INTO _ermrest.known_fkeys (oid, schema_rid, constraint_name, fk_table_rid, pk_table_rid, delete_rule, update_rule)
 SELECT oid, schema_rid, constraint_name, fk_table_rid, pk_table_rid, delete_rule, update_rule
 FROM _ermrest.introspect_fkeys
@@ -714,7 +712,7 @@ WHERE fkey_rid = (
     AND constraint_name = %(constraint_name)s
 )
 RETURNING fkey_rid;
-""" % {
+""") % {
     'table_rid': sql_literal(self.foreign_key.table.rid),
     'constraint_name': sql_literal(self.constraint_name[1]),
     'idx_name': sql_identifier(idx_name),

--- a/ermrest/model/key.py
+++ b/ermrest/model/key.py
@@ -228,8 +228,8 @@ SELECT oid, schema_rid, constraint_name, table_rid, "comment"
 FROM _ermrest.introspect_keys
 WHERE table_rid = %(t_rid)s AND constraint_name = %(c_name)s;
 
-INSERT INTO _ermrest.known_key_columns (key_rid, column_rid)
-SELECT key_rid, column_rid
+INSERT INTO _ermrest.known_key_columns (key_rid, column_rid, "ordinality")
+SELECT key_rid, column_rid, "ordinality"
 FROM _ermrest.introspect_key_columns
 WHERE key_rid = (
   SELECT "RID" 
@@ -857,7 +857,7 @@ WHERE i.fk_table_rid = %(table_rid)s
             if len(columns) == 0:
                 raise exception.BadData('Foreign-key references require at least one column pair.')
 
-            colset = frozenset(columns)
+            colset = OrderedFrozenSet(columns)
 
             if table is None:
                 table = columns[0].table

--- a/ermrest/model/name.py
+++ b/ermrest/model/name.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2019 University of Southern California
+# Copyright 2013-2021 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import psycopg2
 import csv
 import web
 
-from ..util import sql_identifier, sql_literal
+from ..util import sql_identifier, sql_literal, OrderedFrozenSet
 from .. import exception
 from .predicate import Value
 
@@ -155,7 +155,7 @@ def _default_link_cols(cols, left=True, reftable=None):
 
        Raises exception.ConflictModel if no default can be found.
     """
-    constraint_key = frozenset(cols)
+    constraint_key = OrderedFrozenSet(cols)
     table = cols[0].table # any column will do for this
 
     links = []

--- a/ermrest/model/table.py
+++ b/ermrest/model/table.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2019 University of Southern California
+# Copyright 2013-2021 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import web
 from functools import reduce
 
 from .. import exception, ermpath
-from ..util import sql_identifier, sql_literal, table_exists
+from ..util import sql_identifier, sql_literal, table_exists, OrderedFrozenSet
 from .misc import AltDict, AclDict, DynaclDict, keying, annotatable, cache_rights, hasacls, hasdynacls, enforce_63byte_id, sufficient_rights, get_dynacl_clauses
 from .column import Column, FreetextColumn
 from .key import Unique, ForeignKey, KeyReference
@@ -138,7 +138,7 @@ class Table (object):
     def check_primary_keys(self, require):
         try:
             self.check_system_columns()
-            if frozenset([self.columns['RID']]) not in self.uniques:
+            if OrderedFrozenSet([self.columns['RID']]) not in self.uniques:
                 raise exception.ConflictModel('Column "%s"."RID" lacks uniqueness constraint.' % self.name)
         except exception.ConflictModel as te:
             if not require:

--- a/ermrest/sql/ermrest_schema.sql
+++ b/ermrest/sql/ermrest_schema.sql
@@ -1475,7 +1475,7 @@ BEGIN
 
   WITH inserted AS (
     INSERT INTO _ermrest.known_key_columns (key_rid, column_rid, "ordinality")
-    SELECT key_rid, column_rid, "ordinality"
+    SELECT i.key_rid, i.column_rid, i."ordinality"
     FROM _ermrest.introspect_key_columns i
     LEFT JOIN _ermrest.known_key_columns k USING (key_rid, column_rid)
     WHERE k."RID" is NULL
@@ -1813,7 +1813,7 @@ BEGIN
 
   WITH inserted AS (
     INSERT INTO _ermrest.known_key_columns (key_rid, column_rid, "ordinality")
-    SELECT key_rid, column_rid, "ordinality"
+    SELECT i.key_rid, i.column_rid, i."ordinality"
     FROM _ermrest.introspect_key_columns i
     LEFT JOIN _ermrest.known_key_columns k USING (key_rid, column_rid)
     WHERE k."RID" IS NULL
@@ -2469,7 +2469,7 @@ RETURNS TABLE ("RID" text, constraint_name text, table_rid text, comment text) A
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION _ermrest.known_key_columns(ts timestamptz)
-RETURNS TABLE ("RID" text, key_rid text, column_rid text) AS $$
+RETURNS TABLE ("RID" text, key_rid text, column_rid text, "ordinality" int4) AS $$
   SELECT
     s."RID",
     (s.rowdata->>'key_rid')::text "key_rid",
@@ -2480,7 +2480,7 @@ RETURNS TABLE ("RID" text, key_rid text, column_rid text) AS $$
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION _ermrest.known_pseudo_key_columns(ts timestamptz)
-RETURNS TABLE ("RID" text, key_rid text, column_rid text) AS $$
+RETURNS TABLE ("RID" text, key_rid text, column_rid text, "ordinality" int4) AS $$
   SELECT
     s."RID",
     (s.rowdata->>'key_rid')::text "key_rid",

--- a/ermrest/url/ast/model.py
+++ b/ermrest/url/ast/model.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2019 University of Southern California
+# Copyright 2013-2021 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import web
 from ... import exception
 from ... import model
 from .api import Api
-from ...util import negotiated_content_type
+from ...util import negotiated_content_type, OrderedFrozenSet
 
 def _post_commit(handler, resource, content_type='text/plain', transform=lambda v: v):
     handler.emit_headers()
@@ -854,7 +854,7 @@ class Key (Api):
         
     def GET_body(self, conn, cur, conflict_model=False):
         table = self.table.GET_body(conn, cur)
-        cols = frozenset([ table.columns.get_enumerable(c) for c in self.columns ])
+        cols = OrderedFrozenSet([ table.columns.get_enumerable(c) for c in self.columns ])
         if cols not in table.uniques:
             if conflict_model:
                 raise exception.ConflictModel(u'key (%s)' % (u','.join([ str(c.name) for c in cols])))

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -151,5 +151,5 @@ class OrderedFrozenSet (collections.abc.Set):
     def __len__(self): return len(self._members_set)
     def __le__(self, other): return self._members_set <= other
     def __ge__(self, other): return self._members_set >= other
-    def __hash__(self): return hash(self._members)
+    def __hash__(self): return hash(self._members_set)
     def __repr__(self): return '<%s(%r)>' % (type(self).__name__, self._members)

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -1,5 +1,5 @@
 # 
-# Copyright 2012-2020 University of Southern California
+# Copyright 2012-2021 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import web
 import urllib
 import uuid
 import base64
+import collections
 from webauthn2.util import urlquote, negotiated_content_type
 
 __version__ = '0.2.0'
@@ -136,3 +137,19 @@ def service_features():
     return {
         "history_control": True,
     }
+
+class OrderedFrozenSet (collections.abc.Set):
+    """Similar to a regular frozenset but remembers order of input iterable of members.
+    """
+    def __init__(self, iterable):
+        super(OrderedFrozenSet, self).__init__()
+        self._members = tuple(iterable)
+        self._members_set = frozenset(iterable)
+
+    def __contains__(self, x): return x in self._members_set
+    def __iter__(self): return iter(self._members)
+    def __len__(self): return len(self._members_set)
+    def __le__(self, other): return self._members_set <= other
+    def __ge__(self, other): return self._members_set >= other
+    def __hash__(self): return hash(self._members)
+    def __repr__(self): return '<%s(%r)>' % (type(self).__name__, self._members)

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -26,7 +26,7 @@ import base64
 import collections
 from webauthn2.util import urlquote, negotiated_content_type
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 def urlunquote(url):
     text = urllib.parse.unquote_plus(url)

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -136,6 +136,7 @@ def random_name(prefix=''):
 def service_features():
     return {
         "history_control": True,
+        "implicit_fkey_index": True,
     }
 
 class OrderedFrozenSet (collections.abc.Set):


### PR DESCRIPTION
This PR adds a few related changes and necessitates a full ermrest-deploy upgrade sequence to perform schema migration for existing catalogs
1. Start tracking ordinality of elements in a compound key in the stored model
2. Expose the stable ordering for key constraint serializations in the model document
3. Propagate the key field ordering to referencing foreign key constraints
4. Implicitly build an index when adding a compound foreign key

This may allow for better postgres query plans when joining via compound foreign keys. However, the implicit index creation is only for newly added fkeys, it will not happen for preexisting foreign keys in an upgraded catalog.