### PR TITLE
Dynacl rights

### DIFF
--- a/docs/api-doc/data/naming.md
+++ b/docs/api-doc/data/naming.md
@@ -140,6 +140,17 @@ The binning operator is only supported for certain basic column storage types:
 - `numeric`
 - `timestamptz`, `timestamp`
 
+## Rights Summary
+
+In order to discover dynamic, data-dependent access rights for specific records, special *rights summary* operators are allowed in an attribute projection in place of a bare column reference:
+
+- `trs(RID)`
+- `trs(` _in alias_ `:RID)`
+- `tcrs(RID)`
+- `tcrs(` _in alias_ `:RID)`
+
+These operators summarize the rights for the table instance containing the referenced RID column. The `trs` or _table rights summary_ operator yields a JSON formatted object with keys `update` and `delete` mapped to boolean values indicating whether that access is allowed on the record. The `tcrs` or _table and column rights summary_ operator includes the same content and extends it with a third `column_update` key mapped to a sub-object that is keyed by column names, each mapped to a boolean for whether update of that given column is allowed on the record.
+
 ## Data Paths
 
 ERMrest introduces a general path-based syntax for naming data resources with idioms for navigation and filtering of entity sets. The _path_ element of the data resource name always denotes a set of entities or joined entities.  The path must be interpreted from left to right in order to understand its meaning. The denoted entity set is understood upon reaching the right-most element of the path and may be modified by the resource space or _api_ under which the path occurs.

--- a/docs/api-doc/data/naming.md
+++ b/docs/api-doc/data/naming.md
@@ -151,6 +151,8 @@ In order to discover dynamic, data-dependent access rights for specific records,
 
 These operators summarize the rights for the table instance containing the referenced RID column. The `trs` or _table rights summary_ operator yields a JSON formatted object with keys `update` and `delete` mapped to boolean values indicating whether that access is allowed on the record. The `tcrs` or _table and column rights summary_ operator includes the same content and extends it with a third `column_update` key mapped to a sub-object that is keyed by column names, each mapped to a boolean for whether update of that given column is allowed on the record.
 
+This feature is advertised as `"attributegroup_rights_summary": true` in the service features advertisement.
+
 ## Data Paths
 
 ERMrest introduces a general path-based syntax for naming data resources with idioms for navigation and filtering of entity sets. The _path_ element of the data resource name always denotes a set of entities or joined entities.  The path must be interpreted from left to right in order to understand its meaning. The denoted entity set is understood upon reaching the right-most element of the path and may be modified by the resource space or _api_ under which the path occurs.

--- a/docs/api-doc/data/naming.md
+++ b/docs/api-doc/data/naming.md
@@ -151,7 +151,7 @@ In order to discover dynamic, data-dependent access rights for specific records,
 
 These operators summarize the rights for the table instance containing the referenced RID column. The `trs` or _table rights summary_ operator yields a JSON formatted object with keys `update` and `delete` mapped to boolean values indicating whether that access is allowed on the record. The `tcrs` or _table and column rights summary_ operator includes the same content and extends it with a third `column_update` key mapped to a sub-object that is keyed by column names, each mapped to a boolean for whether update of that given column is allowed on the record.
 
-This feature is advertised as `"attributegroup_rights_summary": true` in the service features advertisement.
+These features are advertised as `"trs": true` and `"tcrs": true` in the service features advertisement.
 
 ## Data Paths
 

--- a/docs/api-doc/rest-catalog.md
+++ b/docs/api-doc/rest-catalog.md
@@ -37,7 +37,8 @@ if accessing older catalogs.
 
 Known feature flags at time of writing of this document:
 
-- `attributegroup_rights_summary`: Service supports the `trs(RID)` and `tcrs(RID)` projection functions to retrieve row-level access rights.
+- `trs`: Service supports the `trs(RID)` projection functions to retrieve row-level access rights.
+- `tcrs`: Service supports the `tcrs(RID)` projection functions to retrieve row-level, per-column access rights.
 - `history_control`: Service supports `tag:isrd.isi.edu:2020,history-capture` table annotation to disable history capture.
 - `implicit_fkey_index`: Service will produce indexes for compound foreign keys to allow index-based joins on these reference patterns.
 

--- a/docs/api-doc/rest-catalog.md
+++ b/docs/api-doc/rest-catalog.md
@@ -37,6 +37,7 @@ if accessing older catalogs.
 
 Known feature flags at time of writing of this document:
 
+- `attributegroup_rights_summary`: Service supports the `trs(RID)` and `tcrs(RID)` projection functions to retrieve row-level access rights.
 - `history_control`: Service supports `tag:isrd.isi.edu:2020,history-capture` table annotation to disable history capture.
 
 Generally, absence of a feature flag means the service is running

--- a/ermrest/ermpath/resource.py
+++ b/ermrest/ermpath/resource.py
@@ -2205,7 +2205,6 @@ END
                             else:
                                 raise NotImplementedError('unexpected column update right %r in entity rights summary' % (right,))
                         col_rights = [ '%s, %s' % (sql_literal(c.name), right) for c, right in col_rights.items() ]
-                        web.debug(col_rights)
                         rights['column_update'] = 'jsonb_build_object(%s)' % (','.join(col_rights))
                 select = 'jsonb_build_object(%s)' % (','.join([ '%s::text, %s' % (sql_literal(access), right) for access, right in rights.items() ]))
             elif hasattr(col, 'sql_name_with_talias'):

--- a/ermrest/url/ast/__init__.py
+++ b/ermrest/url/ast/__init__.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2020 University of Southern California
+# Copyright 2013-2021 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -83,3 +83,13 @@ class Binning (Name):
 
     def __str__(self):
         return 'bin(%s)' % (';'.join([Name.__str__(self), str(self.nbins), str(self.minv), str(self.maxv)]))
+
+class RightsSummary (Name):
+    """Represent a rights summary used as an attribute."""
+    def __init__(self, name, summarize_columns=False):
+        Name.__init__(self, name.nameparts)
+        self.rights_summary = True
+        self.summarize_columns = summarize_columns
+
+    def __str__(self):
+        return 'ers(%s)' % (Name.__str__(self),)

--- a/ermrest/url/lex.py
+++ b/ermrest/url/lex.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2010-2018 University of Southern California
+# Copyright 2010-2021 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -100,6 +100,8 @@ keywords = [
     'sum',
     'table',
     'textfacet',
+    'trs',
+    'tcrs',
     'ts'
 ]
 keywords = dict([

--- a/ermrest/url/parse.py
+++ b/ermrest/url/parse.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2010-2019 University of Southern California
+# Copyright 2010-2021 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -408,7 +408,8 @@ def p_attrlist1_grow(p):
 def p_attrcore(p):
     """attrcore : sname
                 | aggfunc
-                | binfunc"""
+                | binfunc
+                | rsfunc """
     p[0] = p[1]
 
 def p_aggfunc_name(p):
@@ -439,6 +440,14 @@ def p_attrcore_agg(p):
 def p_binfunc_3(p):
     """binfunc : BIN '(' sname ';' expr ';' expr ';' expr ')'"""
     p[0] = ast.Binning(p[3], nbins=p[5], minv=p[7], maxv=p[9])
+
+def p_rsfunc_1(p):
+    """rsfunc : TRS '(' sname ')' """
+    p[0] = ast.RightsSummary(p[3])
+
+def p_rsfunc_2(p):
+    """rsfunc : TCRS '(' sname ')' """
+    p[0] = ast.RightsSummary(p[3], True)
 
 def p_leafattritem(p):
     """leafattritem : attrcore"""

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -134,5 +134,6 @@ def random_name(prefix=''):
 
 def service_features():
     return {
+        "attributegroup_rights_summary": True,
         "history_control": True,
     }

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -135,7 +135,8 @@ def random_name(prefix=''):
 
 def service_features():
     return {
-        "attributegroup_rights_summary": True,
+        "trs": True,
+        "tcrs": True,
         "history_control": True,
         "implicit_fkey_index": True,
     }


### PR DESCRIPTION
Adds "trs(alias:RID)" and "tcrs(alias:RID)" projection operators for the attributegroup API.  This allows discovery of per-row rights to allow better client-side UI adaptation for editing controls.