### PR TITLE
Catalog naming and aliasing

### DIFF
--- a/docs/api-doc/index.md
+++ b/docs/api-doc/index.md
@@ -31,6 +31,7 @@ The ERMrest web service model exposes resources to support management of dataset
 
 1. Service: the entire multi-tenant service end-point
 1. [Catalog](model/naming.md#catalog-names): a particular dataset (in one service)
+1. [Catalog Alias](model/naming.md#catalog-aliases): alias for a dataset
 1. [Schema or model resources](model/naming.md)
    1. [Schemata](model/naming.md#model-names): entire data model of a dataset (in one catalog)
    1. [Schema](model/naming.md#schema-names): a particular named subset of a dataset (in one catalog)
@@ -205,6 +206,10 @@ The ERMrest interface supports typical HTTP operations to manage these different
    1. [Catalog Creation](rest-catalog.md#catalog-creation)
    1. [Catalog Retrieval](rest-catalog.md#catalog-retrieval)
    1. [Catalog Deletion](rest-catalog.md#catalog-deletion)
+   1. [Catalog Alias Creation](rest-catalog.md#catalog-alias-creation)
+   1. [Catalog Alias Retrieval](rest-catalog.md#catalog-alias-retrieval)
+   1. [Catalog Alias Update](rest-catalog.md#catalog-alias-update)
+   1. [Catalog Alias Deletion](rest-catalog.md#catalog-alias-deletion)
 1. [Model-level operations](model/rest.md)
    1. [Schemata Retrieval](model/rest.md#schemata-retrieval)
    1. [Bulk Schemata and Table Creation](model/rest.md#bulk-schemata-and-table-creation)

--- a/docs/api-doc/model/naming.md
+++ b/docs/api-doc/model/naming.md
@@ -21,6 +21,25 @@ read-only retrieval of historical resource representations. Only the
 latest, *live* catalog represented by _cid_ without a _revision_
 supports mutation.
 
+## Catalog Aliases
+
+Through an optional alias-management interface, the administrator can bind (or re-bind) additional identifiers for a catalog:
+
+- _service_ `/alias/` _alias_
+
+where the components of this management path are:
+
+- _service_: the ERMrest service endpoint such as `https://www.example.com/ermrest`.
+- _alias_: the additional catalog identifier for one dataset such as `42` or `production`.
+
+The catalog alias has a representation which provides basic management state information about the binding of _alias_ to a storage catalog _cid_ and an alias ownership access control list.
+
+When an alias is bound to a live catalog, it also implicitly exists in the catalog resource space:
+
+- _service_ `/catalog/` _alias_ [ `@` _revision_ ]
+
+where it has a representation mostly based on the bound storage catalog. However, certain lifecycle states can result in _alias_ only existing in the `alias/` management space while not appearing in the `catalog/` access space, i.e. when the alias does not currently resolve to an accessible catalog.
+
 ## Generic Model Sub-Resources
 
 A number of different resource types in the model hierarchy all

--- a/docs/api-doc/rest-catalog.md
+++ b/docs/api-doc/rest-catalog.md
@@ -41,6 +41,8 @@ Known feature flags at time of writing of this document:
 - `tcrs`: Service supports the `tcrs(RID)` projection functions to retrieve row-level, per-column access rights.
 - `history_control`: Service supports `tag:isrd.isi.edu:2020,history-capture` table annotation to disable history capture.
 - `implicit_fkey_index`: Service will produce indexes for compound foreign keys to allow index-based joins on these reference patterns.
+- `catalog_post_input`: The POST `/ermrest/catalog` method accepts JSON input to customize the catalog ID or initial owner ACL.
+- `catalog_alias`: The `/ermrest/alias` resource space and related catalog aliasing features are available.
 
 Generally, absence of a feature flag means the service is running
 older software which predates the release of the feature. A flag will
@@ -55,7 +57,23 @@ The POST method is used to create an empty catalog:
 
     POST /ermrest/catalog HTTP/1.1
     Host: www.example.com
-    
+
+This method supports an optional JSON input document:
+
+    POST /ermrest/catalog HTTP/1.1
+    Host: www.example.com
+    Content-Type: application/json
+
+    {
+      "id": desired catalog id,
+      "owner": administrative ACL
+    }
+
+These fields are optional and, if present, override the default behavior obtained in a POST without input:
+
+- `"id"`: The desired _cid_ to bind (default is a service-generated serial number)
+- `"owner"`: Initial owner-level access control list for the new catalog (default is the requesting client's identity)
+
 On success, this request yields the new catalog identifier, e.g. `42` in this example:
 
     HTTP/1.1 201 Created
@@ -63,40 +81,60 @@ On success, this request yields the new catalog identifier, e.g. `42` in this ex
     Content-Type: application/json
     
     {
-      "id": "42",
-      "snaptime": "2PX-WS30-E58W"
+      "id": "42"
     }
+
+The configured `"owner"` will also appear in the `"acls"` sub-resource of the resulting catalog resource.
 
 Typical error response codes include:
 - 404 Not Found
 - 403 Forbidden
 - 401 Unauthorized
 
+In the rare event that there is a system error during catalog creation, the ERMrest registry of catalogs may retain a record of a claimed catalog identifier without a corresponding catalog database. This record includes the `"owner"` and only clients authorized by that access control list may retry catalog creation with the same desired catalog id.
+
 ## Catalog Retrieval
 
-The GET method is used to get a short description of a catalog:
+The GET method is used to get a short description of a catalog by its canonical identifier or an alias:
 
     GET /ermrest/catalog/42 HTTP/1.1
     Host: www.example.com
     
-On success, this request yields a description:
+On success, this request yields a catalog description:
 
     HTTP/1.1 200 OK
     Content-Type: application/json
     
     {
       "id": "42",
+      "alias_target": target catalog identifier,
+      "rights": {
+        "owner": boolean,
+        "create": boolean
+      },
+      "acls": {
+        "owner": access control list,
+        ...
+      },
       "annotations": {
         "tag:isrd.isi.edu,2018:example": {"value": "my example annotation"}
       },
       "snaptime": "2PX-WS30-E58W",
       "features": {
-         ...
+        ...
       }
     }
 
-The `"features"` field is previously described in the [Service Ad
-Retrieval request](#service-ad-retrieval).
+The fields of this representation are:
+- `"id"`: The identifier for the catalog being addressed (may be an alias or storage catalog identifier).
+- `"alias_target"`: The canonical identifier for the storage catalog (only present when `"id"` is showing an alias instead).
+- `"snaptime"`: The identifier for the snapshot being addressed.
+- `"rights"`: A summary of rights for the requesting client.
+- `"acls"`: Configured access control lists for this catalog.
+- `"annotations"`: Configured annotations for this catalog.
+- `"features"`: The service features advertisement as described in the [Service Ad Retrieval request](#service-ad-retrieval).
+
+This representation summarizes the catalog which is affectively addressed by the catalog URL. Other catalog sub-resources described in this API documentation are likewise available relative to this catalog URL prefix. Access to sub-resources for catalog, schema, and content management and access are consistent whether the catalog URL prefix is using a canonical storage catalog _cid_ or a catalog _alias_.
 
 Typical error response codes include:
 - 404 Not Found
@@ -105,9 +143,139 @@ Typical error response codes include:
 
 ## Catalog Deletion
 
-The DELETE method is used to delete a catalog and all its content:
+The DELETE method is used to delete a catalog:
 
     DELETE /ermrest/catalog/42 HTTP/1.1
+    Host: www.example.com
+
+There are two cases for catalog deletion via this API:
+
+1. When DELETE `/ermrest/catalog/` _alias_ names a catalog by alias: equivalent to DELETE `/ermrest/alias/` _alias_ while the underlying storage catalog is unaffected.
+2. When DELETE `/ermrest/catalog/` _cid_ names a storage catalog identifier, the catalog and its content are destroyed, unbinding (but not destroying) any existing aliases which have _cid_ as their `"alias_target"`.
+
+On success, this request yields a description:
+
+    HTTP/1.1 204 No Content
+
+Typical error response codes include:
+- 404 Not Found
+- 403 Forbidden
+- 401 Unauthorized
+
+## Catalog Alias Creation
+
+The POST method is used to create an alias resource:
+
+    POST /ermrest/alias HTTP/1.1
+    Host: www.example.com
+
+This method supports an optional JSON input document:
+
+    POST /ermrest/alias HTTP/1.1
+    Host: www.example.com
+    Content-Type: application/json
+
+    {
+      "id": desired alias id,
+      "owner": administrative access control list,
+      "alias_target": existing storage catalog id
+    }
+
+These fields are optional and, if present, override the default behavior obtained in a POST without input:
+
+- `"id"`: The desired _alias_ to bind (default is a service-generated serial number)
+- `"owner"`: Initial access control list for the alias (default is the requesting client's identity)
+- `"alias_target"`: Storage catalog to bind with the new alias (default unbound)
+
+An unbound alias can reserve the alias for future use by clients permitted by the adminstrative access control list.
+
+On success, this request yields the new catalog alias, e.g. `my_alias` in this example:
+
+    HTTP/1.1 201 Created
+    Location: /ermrest/catalog/42
+    Content-Type: application/json
+    
+    {
+      "id": "my_alias"
+    }
+
+The configured `"owner"` and `"alias_target"` will also appear in the resulting alias resource.
+
+Typical error response codes include:
+- 404 Not Found
+- 403 Forbidden
+- 401 Unauthorized
+
+## Catalog Alias Retrieval
+
+The GET method is used to get a short description of an alias:
+
+    GET /ermrest/alias/my_alias HTTP/1.1
+    Host: www.example.com
+    
+On success, this request yields a description:
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+    
+    {
+      "id": "my_alias",
+      "owner": administrative access control list,
+      "alias_target": "42"
+    }
+
+The fields of this representation are:
+- `"id"`: The alias identifier.
+- `"owner"`: The access control list granting permission to manage this alias.
+- `"alias_target"`: The canonical identifier for the storage catalog (may be `null` for unbound aliases.
+
+Typical error response codes include:
+- 404 Not Found
+- 403 Forbidden
+- 401 Unauthorized
+
+## Catalog Alias Update
+
+The PUT method is used to modify the configuration of an alias:
+
+    PUT /ermrest/alias/my_alias HTTP/1.1
+    Host: www.example.com
+    Content-Type: application/json
+    
+    {
+      "id": "my_alias",
+      "owner": new administrative access control list,
+      "alias_target": new target catalog identifier
+    }
+
+Either field is optional and defaults to leaving the respective configuration unchanged:
+
+- `"owner"`: Set a new administrative access control list for the alias.
+- `"alias_target"`: Bind or re-bind the alias to the specified storage catalog.
+
+For ease of use, the `"id"` field is also accepted as input, so that an existing alias representation could be edited and resubmitted. However, the included `"id"` field MUST match the _alias_ identifier in the URL.
+
+On success, this request yields a description of the updated alias:
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+    
+    {
+      "id": "my_alias",
+      "owner": administrative access control list,
+      "alias_target": "42"
+    }
+
+Typical error response codes include:
+- 404 Not Found
+- 403 Forbidden
+- 401 Unauthorized
+
+## Catalog Alias Deletion
+
+The DELETE method is used to delete a catalog alias:
+
+    DELETE /ermrest/alias/my_alias HTTP/1.1
     Host: www.example.com
     
 On success, this request yields a description:
@@ -118,4 +286,3 @@ Typical error response codes include:
 - 404 Not Found
 - 403 Forbidden
 - 401 Unauthorized
-

--- a/ermrest/catalog.py
+++ b/ermrest/catalog.py
@@ -118,7 +118,7 @@ class CatalogFactory (object):
             # create catalog
             descriptor = dict(self._template)
             descriptor[self._KEY_DBNAME] = dbname
-            return Catalog(self, descriptor)
+            return Catalog(self, reg_entry={"descriptor": descriptor})
 
         pc = sanepg2.PooledConnection(self._dsn)
         try:
@@ -180,7 +180,7 @@ class Catalog (object):
     MODEL_CACHE = dict()
     MODEL_CACHE_SIZE = 16
 
-    def __init__(self, factory, descriptor, config=None):
+    def __init__(self, factory, reg_entry, config=None):
         """Initializes the catalog.
            
            The 'factory' is the factory used to create this catalog.
@@ -196,9 +196,10 @@ class Catalog (object):
         """
         assert factory is not None
         assert descriptor is not None
-        self.descriptor = descriptor
-        self.dsn = self._serialize_descriptor(descriptor)
+        self.descriptor = reg_entry['descriptor']
+        self.dsn = self._serialize_descriptor(self.descriptor)
         self._factory = factory
+        self.alias_target = reg_entry.get('alias_target')
         self._config = config  # Not sure we need to tuck away the config
 
     def _serialize_descriptor(self, descriptor):

--- a/ermrest/ermrest_apis.py
+++ b/ermrest/ermrest_apis.py
@@ -194,6 +194,8 @@ def web_urls():
 
         # the catalog factory
         '/catalog/?', ast.Catalogs,
+        '/alias/?', ast.CatalogAliases,
+        '/alias/([^/]+)', ast.CatalogAlias,
 
         # core parser-based REST dispatcher
         '(?s).*', Dispatcher

--- a/ermrest/registry.py
+++ b/ermrest/registry.py
@@ -182,6 +182,7 @@ SELECT jsonb_build_object(
 FROM ermrest.simple_registry l
 LEFT OUTER JOIN ermrest.simple_registry t ON (l.alias_target = t.id)
 WHERE l.deleted_on IS NULL
+  AND (l.descriptor IS NOT NULL OR t.descriptor IS NOT NULL OR %(dangling)s::boolean)
   AND (t.id IS NULL OR t.deleted_on IS NULL OR %(dangling)s::boolean)
   AND (l.id = %(id)s::text OR %(id)s::text IS NULL)
 """ % {

--- a/ermrest/registry.py
+++ b/ermrest/registry.py
@@ -225,7 +225,7 @@ SELECT nextval('ermrest.simple_registry_id_seq');
                 claim_id = id
 
             # idempotent claim pre-checks
-            rows = self._lookup(conn, cur, id=id, dangling=True)
+            rows = self._lookup(conn, cur, id=claim_id, dangling=True)
             if rows:
                 entry = rows[0]
                 old_id_owner = entry['id_owner'] if entry['id_owner'] else []

--- a/ermrest/registry.py
+++ b/ermrest/registry.py
@@ -217,6 +217,10 @@ WHERE l.deleted_on IS NULL
                 owner = [ web.ctx.webauthn2_context.client_id ]
             else:
                 owner = id_owner
+
+            if set(owner).isdisjoint(set(web.ctx.webauthn2_context.attribute_ids)):
+                raise exception.ConflictData('Cannot set owner ACL to exclude self.')
+
             if id is None:
                 cur.execute("""
 SELECT nextval('ermrest.simple_registry_id_seq');

--- a/ermrest/sql/registry.sql
+++ b/ermrest/sql/registry.sql
@@ -1,6 +1,6 @@
 
 -- 
--- Copyright 2012-2017 University of Southern California
+-- Copyright 2012-2021 University of Southern California
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -15,24 +15,23 @@
 -- limitations under the License.
 --
 
-DO $$
-BEGIN
+CREATE SCHEMA IF NOT EXISTS ermrest;
 
-IF (SELECT True FROM information_schema.schemata WHERE schema_name = 'ermrest') IS NULL THEN
-  CREATE SCHEMA ermrest;
-END IF;
+CREATE SEQUENCE IF NOT EXISTS ermrest.simple_registry_id_seq;
 
-IF (SELECT True FROM information_schema.tables WHERE table_schema = 'ermrest' AND table_name = 'simple_registry') IS NULL THEN
-  CREATE TABLE ermrest.simple_registry (
-    id bigserial PRIMARY KEY,
-    descriptor text,
-    deleted_on timestamp with time zone DEFAULT NULL,
-    created_on timestamp with time zone DEFAULT (now())
-  );
-  CREATE INDEX IF NOT EXISTS simple_registry_deleted_on_idx    ON ermrest.simple_registry (deleted_on);
-  CREATE INDEX IF NOT EXISTS simple_registry_id_notdeleted_idx ON ermrest.simple_registry (id) WHERE deleted_on IS NULL;
-  CREATE INDEX IF NOT EXISTS simple_registry_created_on_idx    ON ermrest.simple_registry (created_on);
-END IF;
+CREATE TABLE IF NOT EXISTS ermrest.simple_registry (
+  id text PRIMARY KEY DEFAULT (nextval('ermrest.simple_registry_id_seq')::text),
+  id_owner text[],
+  descriptor jsonb,
+  alias_target text,
+  created_on timestamp with time zone DEFAULT (now()),
+  deleted_on timestamp with time zone DEFAULT NULL,
+  CONSTRAINT simple_registry_alias_target_fkey
+    FOREIGN KEY (alias_target) REFERENCES ermrest.simple_registry(id)
+    ON UPDATE CASCADE ON DELETE SET NULL
+);
 
-END;
-$$ LANGUAGE plpgsql;
+CREATE INDEX IF NOT EXISTS simple_registry_deleted_on_idx    ON ermrest.simple_registry (deleted_on);
+CREATE INDEX IF NOT EXISTS simple_registry_created_on_idx    ON ermrest.simple_registry (created_on);
+CREATE INDEX IF NOT EXISTS simple_registry_id_notdeleted_idx ON ermrest.simple_registry (id) WHERE deleted_on IS NULL;
+CREATE INDEX IF NOT EXISTS simple_registry_id_target_notdeleted_idx ON ermrest.simple_registry (id, alias_target) WHERE deleted_on IS NULL;

--- a/ermrest/sql/upgrade_registry.sql
+++ b/ermrest/sql/upgrade_registry.sql
@@ -29,6 +29,7 @@ IF (SELECT True
   -- perform catalog naming feature upgrade
   ALTER TABLE ermrest.simple_registry
     ALTER COLUMN id TYPE text,
+    ALTER COLUMN descriptor TYPE jsonb USING (descriptor::jsonb),
     ADD COLUMN id_owner text[],
     ADD COLUMN alias_target text,
     ADD CONSTRAINT simple_registry_alias_target_fkey

--- a/ermrest/sql/upgrade_registry.sql
+++ b/ermrest/sql/upgrade_registry.sql
@@ -28,7 +28,7 @@ IF (SELECT True
 
   -- perform catalog naming feature upgrade
   ALTER TABLE ermrest.simple_registry
-    ALTER COLUMN id SET TYPE text,
+    ALTER COLUMN id TYPE text,
     ADD COLUMN id_owner text[],
     ADD COLUMN alias_target text,
     ADD CONSTRAINT simple_registry_alias_target_fkey
@@ -38,4 +38,4 @@ IF (SELECT True
 END IF;
 
 END;
-$$ LANGUAGE plpgsql
+$$ LANGUAGE plpgsql;

--- a/ermrest/sql/upgrade_registry.sql
+++ b/ermrest/sql/upgrade_registry.sql
@@ -1,6 +1,6 @@
 
 -- 
--- Copyright 2017 University of Southern California
+-- Copyright 2017, 2021 University of Southern California
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -16,3 +16,26 @@
 --
 
 DROP INDEX IF EXISTS ermrest.simple_registry_id_deleted_on_idx;
+
+DO $$
+BEGIN
+
+IF (SELECT True
+    FROM information_schema.columns
+    WHERE table_schema = 'ermrest'
+      AND table_name = 'simple_registry'
+      AND column_name = 'alias_target') IS NULL THEN
+
+  -- perform catalog naming feature upgrade
+  ALTER TABLE ermrest.simple_registry
+    ALTER COLUMN id SET TYPE text,
+    ADD COLUMN id_owner text[],
+    ADD COLUMN alias_target text,
+    ADD CONSTRAINT simple_registry_alias_target_fkey
+      FOREIGN KEY (alias_target) REFERENCES ermrest.simple_registry(id)
+      ON UPDATE CASCADE ON DELETE SET NULL;
+
+END IF;
+
+END;
+$$ LANGUAGE plpgsql

--- a/ermrest/sql/util.py
+++ b/ermrest/sql/util.py
@@ -1,6 +1,6 @@
 
 #
-# Copyright 2017 University of Southern California
+# Copyright 2017-2021 University of Southern California
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,10 @@ def for_each_catalog(thunk, id=None):
 
     results = registry.lookup(id)
     for entry in results:
+        if entry.get('alias_target') is None:
+            # lookup can return the same descriptor more than once
+            # ignore aliased references
+            continue
         catalog = Catalog(catalog_factory, reg_entry=entry)
         # a non-shared pool is just our same API w/o pooling...
         pc = sanepg2.PooledConnection(catalog.dsn, shared=False)

--- a/ermrest/sql/util.py
+++ b/ermrest/sql/util.py
@@ -28,8 +28,8 @@ def for_each_catalog(thunk, id=None):
         raise NotImplementedError('ERMrest catalog registry not configured.')
 
     results = registry.lookup(id)
-    for result in results:
-        catalog = Catalog(catalog_factory, result['descriptor'])
+    for entry in results:
+        catalog = Catalog(catalog_factory, reg_entry=entry)
         # a non-shared pool is just our same API w/o pooling...
         pc = sanepg2.PooledConnection(catalog.dsn, shared=False)
         next(pc.perform(lambda conn, cur: thunk(catalog, conn, cur), verbose=False))

--- a/ermrest/url/ast/__init__.py
+++ b/ermrest/url/ast/__init__.py
@@ -28,7 +28,7 @@ once an appropriate database connection is available.
 
 import urllib
 
-from .catalog import Service, Catalogs, Catalog
+from .catalog import Service, Catalogs, Catalog, CatalogAliases, CatalogAlias
 from ...model.name import Name, NameList
 from . import history
 

--- a/ermrest/url/ast/api.py
+++ b/ermrest/url/ast/api.py
@@ -200,6 +200,12 @@ class Api (ApiBase):
         )
         super(Api, self)._prepare()
 
+    def set_http_etag(self, version):
+        if self.catalog.manager.alias_target is not None:
+            return super(Api, self).set_http_etag('%s-%s' % (version, self.catalog.manager.alias_target))
+        else:
+            return super(Api, self).set_http_etag(version)
+
     def client_register_body(self, conn, cur):
         client = web.ctx.webauthn2_context.client
         if isinstance(client, dict):

--- a/ermrest/url/ast/api.py
+++ b/ermrest/url/ast/api.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2019 University of Southern California
+# Copyright 2013-2021 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,120 @@ from ... import sanepg2
 from ...model import normalized_history_snaptime
 from ...util import sql_literal, negotiated_content_type
 
-class Api (object):
+class ApiBase (object):
+    def _prepare(self):
+        self.http_vary = web.ctx.webauthn2_manager.get_http_vary()
+        self.http_etag = None
+
+    def set_http_etag(self, version):
+        """Set an ETag from version key.
+
+        """
+        etag = []
+
+        # TODO: compute source_checksum to help with cache invalidation
+        #etag.append( source_checksum )
+
+        if 'cookie' in self.http_vary:
+            client = web.ctx.webauthn2_context.client
+            if isinstance(client, dict):
+                client = client['id']
+            etag.append( '%s' % client )
+        else:
+            etag.append( '*' )
+
+        if 'accept' in self.http_vary:
+            etag.append( '%s' % web.ctx.env.get('HTTP_ACCEPT', '') )
+        else:
+            etag.append( '*' )
+
+        etag.append( '%s' % version )
+
+        self.http_etag = '"%s"' % ';'.join(etag).replace('"', '\\"')
+
+    def parse_client_etags(self, header):
+        """Parse header string for ETag-related preconditions.
+
+           Returns dict mapping ETag -> boolean indicating strong
+           (true) or weak (false).
+
+           The special key True means the '*' precondition was
+           encountered which matches any representation.
+
+        """
+        def etag_parse(s):
+            strong = True
+            if s[0:2] == 'W/':
+                strong = False
+                s = s[2:]
+            if s[-6:] == '-gzip"':
+                # remove stupid suffix added by mod_deflate
+                s = s[:-6] + '"'
+            return (s, strong)
+
+        s = header
+        etags = []
+        # pick off one ETag prefix at a time, consuming comma-separated list
+        while s:
+            s = s.strip()
+            # accept leading comma that isn't really valid by spec...
+            m = re.match('^,? *(?P<first>(W/)?"([^"]|\\\\")*")(?P<rest>.*)', s)
+            if m:
+                # found 'W/"tag"' or '"tag"'
+                g = m.groupdict()
+                etags.append(etag_parse(g['first']))
+                s = g['rest']
+                continue
+            m = re.match('^,? *[*](?P<rest>.*)', s)
+            if m:
+                # found '*'
+                # accept anywhere in list even though spec is more strict...
+                g = m.groupdict()
+                etags.append((True, True))
+                s = g['rest']
+                continue
+            s = None
+
+        return dict(etags)
+
+    def http_check_preconditions(self, method='GET', resource_exists=True):
+        failed = False
+
+        match_etags = self.parse_client_etags(web.ctx.env.get('HTTP_IF_MATCH', ''))
+        if match_etags:
+            if resource_exists:
+                if self.http_etag and self.http_etag not in match_etags \
+                   and (True not in match_etags):
+                    failed = True
+            else:
+                failed = True
+
+        nomatch_etags = self.parse_client_etags(web.ctx.env.get('HTTP_IF_NONE_MATCH', ''))
+        if nomatch_etags:
+            if resource_exists:
+                if self.http_etag and self.http_etag in nomatch_etags \
+                   or (True in nomatch_etags):
+                    failed = True
+
+        if failed:
+            headers = {
+                "ETag": self.http_etag,
+                "Vary": ", ".join(self.http_vary),
+            }
+            if method == 'GET':
+                raise rest.NotModified(headers=headers)
+            else:
+                raise rest.PreconditionFailed(headers=headers)
+
+    def emit_headers(self):
+        """Emit any automatic headers prior to body beginning."""
+        #TODO: evaluate whether this function is necessary
+        if self.http_vary:
+            web.header('Vary', ', '.join(self.http_vary))
+        if self.http_etag:
+            web.header('ETag', '%s' % self.http_etag)
+
+class Api (ApiBase):
 
     # caches keyed by (catalog descriptor, identifier URI/guid)
     CLIENT_CACHE = OrderedDict()
@@ -64,6 +177,7 @@ class Api (object):
         cache[key] = datetime.datetime.utcnow()
 
     def __init__(self, catalog):
+        super(Api, self).__init__()
         self.catalog = catalog
         self.queryopts = dict()
         self.sort = None
@@ -84,8 +198,7 @@ class Api (object):
             snapwhen=web.ctx.ermrest_history_snaptime,
             amendver=web.ctx.ermrest_history_amendver
         )
-        self.http_vary = web.ctx.webauthn2_manager.get_http_vary()
-        self.http_etag = None
+        super(Api, self)._prepare()
 
     def client_register_body(self, conn, cur):
         client = web.ctx.webauthn2_context.client
@@ -268,114 +381,6 @@ SET "Display_Name" = excluded."Display_Name";
             except:
                 return 100
     
-    def set_http_etag(self, version):
-        """Set an ETag from version key.
-
-        """
-        etag = []
-
-        # TODO: compute source_checksum to help with cache invalidation
-        #etag.append( source_checksum )
-
-        if 'cookie' in self.http_vary:
-            client = web.ctx.webauthn2_context.client
-            if isinstance(client, dict):
-                client = client['id']
-            etag.append( '%s' % client )
-        else:
-            etag.append( '*' )
-            
-        if 'accept' in self.http_vary:
-            etag.append( '%s' % web.ctx.env.get('HTTP_ACCEPT', '') )
-        else:
-            etag.append( '*' )
-
-        etag.append( '%s' % version )
-
-        self.http_etag = '"%s"' % ';'.join(etag).replace('"', '\\"')
-
-    def parse_client_etags(self, header):
-        """Parse header string for ETag-related preconditions.
-
-           Returns dict mapping ETag -> boolean indicating strong
-           (true) or weak (false).
-
-           The special key True means the '*' precondition was
-           encountered which matches any representation.
-
-        """
-        def etag_parse(s):
-            strong = True
-            if s[0:2] == 'W/':
-                strong = False
-                s = s[2:]
-            if s[-6:] == '-gzip"':
-                # remove stupid suffix added by mod_deflate
-                s = s[:-6] + '"'
-            return (s, strong)
-
-        s = header
-        etags = []
-        # pick off one ETag prefix at a time, consuming comma-separated list
-        while s:
-            s = s.strip()
-            # accept leading comma that isn't really valid by spec...
-            m = re.match('^,? *(?P<first>(W/)?"([^"]|\\\\")*")(?P<rest>.*)', s)
-            if m:
-                # found 'W/"tag"' or '"tag"'
-                g = m.groupdict()
-                etags.append(etag_parse(g['first']))
-                s = g['rest']
-                continue
-            m = re.match('^,? *[*](?P<rest>.*)', s)
-            if m:
-                # found '*'
-                # accept anywhere in list even though spec is more strict...
-                g = m.groupdict()
-                etags.append((True, True))
-                s = g['rest']
-                continue
-            s = None
-
-        return dict(etags)
-        
-    def http_check_preconditions(self, method='GET', resource_exists=True):
-        failed = False
-
-        match_etags = self.parse_client_etags(web.ctx.env.get('HTTP_IF_MATCH', ''))
-        if match_etags:
-            if resource_exists:
-                if self.http_etag and self.http_etag not in match_etags \
-                   and (True not in match_etags):
-                    failed = True
-            else:
-                failed = True
-        
-        nomatch_etags = self.parse_client_etags(web.ctx.env.get('HTTP_IF_NONE_MATCH', ''))
-        if nomatch_etags:
-            if resource_exists:
-                if self.http_etag and self.http_etag in nomatch_etags \
-                   or (True in nomatch_etags):
-                    failed = True
-
-        if failed:
-            headers={ 
-                "ETag": self.http_etag, 
-                "Vary": ", ".join(self.http_vary)
-            }
-            if method == 'GET':
-                raise rest.NotModified(headers=headers)
-            else:
-                raise rest.PreconditionFailed(headers=headers)
-
-    def emit_headers(self):
-        """Emit any automatic headers prior to body beginning."""
-        #TODO: evaluate whether this function is necessary
-        if self.http_vary:
-            web.header('Vary', ', '.join(self.http_vary))
-        if self.http_etag:
-            web.header('ETag', '%s' % self.http_etag)
-        
     def perform(self, body, finish):
         def wrapbody(conn, cur):
             try:

--- a/ermrest/url/ast/catalog.py
+++ b/ermrest/url/ast/catalog.py
@@ -160,11 +160,12 @@ class Catalog (Api):
         entries = web.ctx.ermrest_registry.lookup(catalog_id)
         if not entries:
             raise exception.rest.NotFound('catalog ' + str(catalog_id))
+        entry = entries[0]
         self.manager = catalog.Catalog(
             web.ctx.ermrest_catalog_factory, 
-            entries[0]['descriptor'],
-            web.ctx.ermrest_config
-            )
+            reg_entry=entry,
+            config=web.ctx.ermrest_config,
+        )
         
         assert web.ctx.ermrest_catalog_pc is None
         web.ctx.ermrest_catalog_pc = sanepg2.PooledConnection(self.manager.dsn)
@@ -247,6 +248,8 @@ class Catalog (Api):
             # not ever be shared.
             resource = _model.prejson(brief=True, snaptime=self.catalog_snaptime)
             resource["id"] = self.catalog_id
+            if self.manager.alias_target is not None:
+                resource["alias_target"] = self.manager.alias_target
             response = json.dumps(resource) + '\n'
             if self.catalog_amendver:
                 self.set_http_etag( '%s-%s' % (self.catalog_snaptime, self.catalog_amendver) )

--- a/ermrest/url/ast/catalog.py
+++ b/ermrest/url/ast/catalog.py
@@ -21,9 +21,11 @@
 import json
 import web
 import psycopg2.extensions
+import base64
+import hashlib
 
 from . import model, data, resolver
-from .api import Api, negotiated_content_type
+from .api import ApiBase, Api, negotiated_content_type
 from ... import exception, catalog, sanepg2
 from ...apicore import web_method
 from ...exception import *
@@ -114,6 +116,54 @@ class Catalogs (object):
 
         # register the catalog descriptor
         entry = web.ctx.ermrest_registry.register(catalog_id, descriptor=catalog.descriptor)
+
+        web.header('Content-Type', content_type)
+        web.ctx.ermrest_request_content_type = content_type
+
+        # set location header and status
+        location = '/ermrest/catalog/%s' % catalog_id
+        web.header('Location', location)
+        web.ctx.status = '201 Created'
+
+        if content_type == _text_plain:
+            return str(catalog_id)
+        else:
+            assert content_type == _application_json
+            return json.dumps(dict(id=catalog_id))
+
+class CatalogAliases (object):
+    """A multi-tenant catalog alias set."""
+
+    default_content_type = _application_json
+    supported_types = [default_content_type, _text_plain]
+
+    @web_method()
+    def POST(self, uri='catalog'):
+        """Perform HTTP POST of catalog aliases.
+        """
+        # content negotiation
+        content_type = negotiated_content_type(self.supported_types, self.default_content_type)
+
+        # registry acl enforcement
+        allowed = web.ctx.ermrest_registry.can_create(web.ctx.webauthn2_context.attributes)
+        if not allowed:
+            raise rest.Forbidden(uri)
+
+        # optional input
+        docstr = web.ctx.env['wsgi.input'].read().decode().strip()
+        if docstr:
+            try:
+                doc = json.loads(docstr)
+            except:
+                raise exception.rest.BadRequest('Could not deserialize JSON input.')
+        else:
+            doc = {}
+
+        # create the alias entry
+        catalog_id = web.ctx.ermrest_registry.claim_id(id=doc.get('id'), id_owner=doc.get('owner'))
+
+        # register the catalog descriptor
+        entry = web.ctx.ermrest_registry.register(catalog_id, alias_target=doc.get('alias_target'))
 
         web.header('Content-Type', content_type)
         web.ctx.ermrest_request_content_type = content_type
@@ -315,6 +365,146 @@ class Catalog (Api):
             return ''
 
         return self.perform(body, post_commit)
+
+class CatalogAlias (ApiBase):
+
+    default_content_type = _application_json
+    supported_types = [default_content_type]
+
+    """A specific catalog by ID."""
+    def _prepare(self, catalog_id, missing_ok=False):
+        super(CatalogAlias, self)._prepare()
+
+        self.catalog_id = catalog_id
+        entries = web.ctx.ermrest_registry.lookup(catalog_id, dangling=True)
+        if not entries:
+            if missing_ok:
+                self.entry = None
+                self.set_http_etag('None')
+                return
+            raise exception.rest.NotFound('alias/%s' % (catalog_id,))
+        self.entry = entries[0]
+        if self.entry['descriptor'] is not None and self.entry['alias_target'] is None:
+            # regular catalog entry is not an alias
+            raise exception.rest.NotFound('alias/%s' % (catalog_id,))
+
+        # now enforce read permission
+        self.enforce_right('enumerate')
+        self.set_http_etag()
+
+    def set_http_etag(self, version=None):
+        if version is None:
+            normalized = [
+                self.entry['id'],
+                self.entry['id_owner'],
+                self.entry['alias_target'],
+            ]
+            version = base64.urlsafe_b64encode(hashlib.md5(json.dumps(normalized).encode('utf8')).digest()).decode()
+        super(CatalogAlias, self).set_http_etag(version)
+
+    @property
+    def id_owner(self):
+        if isinstance(self.entry['id_owner'], list):
+            return self.entry['id_owner']
+        else:
+            return []
+
+    def enforce_right(self, acl):
+        if set(self.id_owner).isdisjoint(web.ctx.webauthn2_context.attribute_ids):
+            raise exception.Forbidden('%s access to alias/%s' % (acl, self.catalog_id))
+
+    def final(self):
+        pass
+
+    def prejson(self):
+        return {
+            'id': self.entry['id'],
+            'owner': self.entry['id_owner'],
+            'alias_target': self.entry['alias_target'],
+        }
+
+    @web_method()
+    def GET(self, catalog_id):
+        """Perform HTTP retrieval of catalog alias registry entry
+        """
+        self._prepare(catalog_id)
+        # content negotiation
+        content_type = negotiated_content_type(self.supported_types, self.default_content_type)
+        web.ctx.ermrest_request_content_type = content_type
+
+        resource = self.prejson()
+        response = json.dumps(resource) + '\n'
+        self.http_check_preconditions()
+        self.emit_headers()
+        web.header('Content-Type', content_type)
+        web.header('Content-Length', len(response))
+        return response
+
+    @web_method()
+    def PUT(self, catalog_id):
+        """Perform HTTP update/create of catalog alias registry entry
+        """
+        self._prepare(catalog_id, missing_ok=True)
+        self.http_check_preconditions()
+
+        # optional input
+        docstr = web.ctx.env['wsgi.input'].read().decode().strip()
+        if docstr:
+            try:
+                doc = json.loads(docstr)
+            except:
+                raise exception.rest.BadRequest('Could not deserialize JSON input.')
+        else:
+            doc = {}
+
+        if doc.get('id', catalog_id) != catalog_id:
+            raise exception.rest.BadRequest('Alias id=%s in body does not match id=%s in URL..' % (doc.get('id'), catalog_id))
+
+        if self.entry is None:
+            # check static permissions as in POST alias/
+            allowed = web.ctx.ermrest_registry.can_create(web.ctx.webauthn2_context.attributes)
+            if not allowed:
+                raise rest.Forbidden('alias/%s' % (catalog_id,))
+
+        # abuse idempotent claim to update and to check existing claim permissions
+        catalog_id = web.ctx.ermrest_registry.claim_id(id=catalog_id, id_owner=doc.get('owner'))
+
+        # update the alias config
+        entry = web.ctx.ermrest_registry.register(catalog_id, alias_target=doc.get('alias_target'))
+
+        content_type = _application_json
+        web.ctx.ermrest_request_content_type = content_type
+        response = json.dumps({
+            'id': entry['id'],
+            'owner': entry['id_owner'],
+            'alias_target': entry['alias_target'],
+        }) + '\n'
+
+        web.header('Content-Type', content_type)
+        web.header('Content-Length', len(response))
+
+        # set location header and status
+        if self.entry is None:
+            location = '/ermrest/alias/%s' % catalog_id
+            web.header('Location', location)
+            web.ctx.status = '201 Created'
+        else:
+            web.ctx.ermrest_request_content_type = None
+            web.ctx.status = '200 OK'
+
+        return response
+
+    @web_method()
+    def DELETE(self, catalog_id):
+        """Perform HTTP DELETE of catalog alias.
+        """
+        self._prepare(catalog_id)
+        self.http_check_preconditions()
+
+        self.enforce_right('owner')
+        web.ctx.ermrest_registry.unregister(self.catalog_id)
+        web.ctx.status = '204 No Content'
+        return ''
 
 class Meta (Api):
     """A metadata set of the catalog.

--- a/ermrest/url/ast/model.py
+++ b/ermrest/url/ast/model.py
@@ -94,7 +94,12 @@ class Schemas (Api):
         return web.ctx.ermrest_catalog_model
         
     def GET(self, uri):
-        return _GET(self, self.GET_body, _post_commit_json)
+        def _post_commit(handler, model):
+            doc = model.prejson()
+            if self.catalog.manager.alias_target is not None:
+                doc['alias_target'] = self.catalog.manager.alias_target
+            return _post_commit_json(handler, doc)
+        return _GET(self, self.GET_body, _post_commit)
 
     def POST_body(self, conn, cur, doc):
         """Create schemas and/or tables."""

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -139,6 +139,8 @@ def service_features():
         "tcrs": True,
         "history_control": True,
         "implicit_fkey_index": True,
+        "catalog_post_input": True,
+        "catalog_alias": True,
     }
 
 class OrderedFrozenSet (collections.abc.Set):

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -26,7 +26,7 @@ import base64
 import collections
 from webauthn2.util import urlquote, negotiated_content_type
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 def urlunquote(url):
     text = urllib.parse.unquote_plus(url)

--- a/sbin/ermrest-freetext-indices
+++ b/sbin/ermrest-freetext-indices
@@ -91,9 +91,13 @@ def main(argv):
 
     result = ermrest.registry.lookup(catalog_id)
     if not result:
-        sys.stderr.write("Catalog '%d' not found in registry.\n" % catalog_id)
+        sys.stderr.write("Catalog '%s' not found in registry.\n" % catalog_id)
         return 3
     entry = result[0]
+    alias_target = entry.get('alias_target')
+    if alias_target is not None:
+        sys.stderr.write("Ignoring catalog '%s' which is an alias. HINT: index storage catalog '%s' instead." % (catalog_id, alias_target))
+        return 3
 
     catalog = ermrest.Catalog(ermrest.catalog_factory, reg_entry=entry)
     

--- a/sbin/ermrest-freetext-indices
+++ b/sbin/ermrest-freetext-indices
@@ -93,9 +93,9 @@ def main(argv):
     if not result:
         sys.stderr.write("Catalog '%d' not found in registry.\n" % catalog_id)
         return 3
-    catalog_descriptor = result[0]['descriptor']
+    entry = result[0]
 
-    catalog = ermrest.Catalog(ermrest.catalog_factory, catalog_descriptor)
+    catalog = ermrest.Catalog(ermrest.catalog_factory, reg_entry=entry)
     
     try:
         pc = ermrest.sanepg2.PooledConnection(catalog.dsn)

--- a/sbin/ermrest-registry-purge
+++ b/sbin/ermrest-registry-purge
@@ -113,8 +113,10 @@ do
         continue
     fi
 
+    # NOTE: empty string "$db" means we found an alias to delete
+    
     # force disconnect of clients, optional
-    if [ -n "${FORCE}" ]; then
+    if [ -n "$db" -a -n "${FORCE}" ]; then
         psql -q "${ERMREST}" >/dev/null <<EOF
 SELECT pid, (SELECT pg_terminate_backend(pid)) as killed
 FROM pg_stat_activity
@@ -128,7 +130,7 @@ EOF
     fi
 
     # dump database to archive directory before purge, optional
-    if [ -n "${ARCHIVE}" ]; then
+    if [ -n "$db" -a -n "${ARCHIVE}" ]; then
         filename="${ARCHIVE}/${id}-${db}-`date +%s`.sql"
         pg_dump --blobs --no-owner "${db}" >"${filename}"
         if [ $? -eq 0 -a -s "${filename}" ]; then
@@ -142,12 +144,15 @@ EOF
     fi
 
     # drop database
-    dropdb --if-exists "${db}"
-    if [ $? -ne 0 ]; then
-        log " DROP FAILED\n"
-        continue
+    if [[ -n "$db" ]]
+    then
+        dropdb --if-exists "${db}"
+        if [ $? -ne 0 ]; then
+            log " DROP FAILED\n"
+            continue
+        fi
+        log " DROPPED"
     fi
-    log " DROPPED"
 
     # delete registry entry of catalog
     psql -q -c "DELETE FROM ermrest.simple_registry WHERE id = '${id}'" ${ERMREST}

--- a/test/resttest/degenerate.py
+++ b/test/resttest/degenerate.py
@@ -11,6 +11,23 @@ from common import Int4, Int8, Text, Int4Array, TextArray, Timestamptz, \
     RID, RCT, RMT, RCB, RMB, RidKey, \
     ModelDoc, SchemaDoc, TableDoc, ColumnDoc, KeyDoc, FkeyDoc
 
+class Disownership (common.ErmrestTest):
+    # should not be able to set owner acls to exclude ourselves
+
+    bad_acl = [ 'junk identity' ]
+
+    def _test_disown(self, url, method='post', json=None, status=(409, 403)):
+        if json is None:
+            json = self.bad_acl
+        r = getattr(self.session, method)(url, json=json)
+        self.assertHttp(r, status)
+    
+    def test_create_disowned_alias(self):
+        self._test_disown('/ermrest/alias', json={"owner": self.bad_acl})
+
+    def test_create_disowned_catalog(self):
+        self._test_disown('/ermrest/catalog', json={"owner": self.bad_acl})
+
 class LongIdentifiers (common.ErmrestTest):
     identifier = u'ǝɯɐuǝɯɐuǝɯǝɯɐuǝɯɐuǝɯɐuǝɯɐuǝɯɐuǝɯɐuɐu'
     utf8 = None


### PR DESCRIPTION
This PR introduces concetually related mechanisms:
1. Optional input during catalog creation
2. A new catalog alias management interface
3. Mostly transparent resolution of catalog aliases for existing APIs

## Catalog creation input

The optional JSON input to the existing `POST /ermrest/catalog` request allows two aspects of control (possibly worth extending further in the future):

```
{
   "id": desired catalog id string,
   "owner": initial catalog owner ACL
}
```
The client-selected identifier must be unique in the service and is immutable, set once for the life of the catalog. It overrides the default serial-numbered id generator. The ownership ACL allows override of the initial ownership ACL which by default is a list with just the requesting client's authenticated identity.

## Catalog Alias Management

A new category of service resource is introduced under the `/ermrest/alias` path. Much like catalogs, aliases can be created with a desired identifier and ownership ACL.  Additionally, they can be bound to an existing regular catalog to introduce an alias for that catalog. Significantly, the alias can be revised to bind to a different catalog in the future via an update request.

- `POST /ermrest/alias` w/ JSON input to create an alias
- `GET /ermrest/alias/` _alias_ to retrieve current state of an alias
- `PUT /ermrest/alias/` _alias_ w/ JSON input to update state of an alias
- `DELETE /ermrest/alias/` _alias_ to destroy an alias

The representation of an alias is much like the input document to catalog creation described above:

```
{
   "id": desired alias id,
   "owner": alias ownership ACL,
   "alias_target": identifier for regular catalog being aliased
}
```
The alias identifiers are managed in the same namespace as catalog identifiers, so all aliases and catalogs must have mutually distinct identifier strings in a given service instance. For consistency, an alias can be generated with a serial numbered identifier if the client omits a desired identifier during alias creation; however, most value of aliasing is probably derived from client-controlled alias identifiers.

The ownership ACL for an alias provides administrative rights to update the alias binding. It does not affect access permissions on an actual catalog.

The alias target field binds the alias to an existing catalog by its immutable identifier. It defaults to `null` meaning that the alias is not bound to a catalog. In effect, an unbound alias is just a reserved identifier which has not yet been put into service.  An alias can also revert to this unbound status later, whether through an explicit update or because the target catalog has been deleted.

## Alias-based Catalog Resolution

For backwards-compatibility, most features of ERMrest work transparently when addressing catalogs and their sub-resources via `/ermrest/catalog/` _alias_ URL prefixes:
- Introspection of catalog and schema
- Management of catalog schema
- Access to catalog data

Exceptions to this rule are mainly for safety:
- During catalog or schema introspection, an extra `"alias_target"` field appears in the top-level document to expose the alias binding target addressed by an alias. This allows clients to retarget to the actual storage catalog if desired, i.e. to form a stable URL reference to a given catalog snapshot. However, naive clients can ignore this and operate as if the alias is a real catalog identifier.
- The `DELETE` method on `/ermrest/catalog/` _alias_ behaves the same as `DELETE /ermrest/alias/` _alias_ so it only removes the alias from the service, without destroying the actual storage catalog. An operator wishing to delete a catalog must determine the actual storage identifier and address it directly.

## Claiming Identifiers

As a convenience, the alias management mechanism also allows for conversion of an unbound alias to a catalog. This allows a client to reserve an identifier ahead of time and then create a new catalog by claiming that same identifier.

1. Establish an unbound alias `{"id": ` _new id_ `, "alias_target": null}`
2. Specify the same identifier during catalog creation `{"id": ` _new id_ `, ...}`

This conversion is "one-way". Once the identifier is claimed by the newly created catalog, it will no longer be available for management via the alias managment interface. However, once the catalog is deleted and completely purged from the service, the identifier MAY be available for use again. (Whether deleted catalogs are purged is at the discretion of the service operator, and not something controlled by web clients!)