### PR TITLE
Expose registry as a catalog

### DIFF
--- a/docs/api-doc/rest-catalog.md
+++ b/docs/api-doc/rest-catalog.md
@@ -47,6 +47,7 @@ Known feature flags at time of writing of this document:
 - `quantified_value_lists`: Service supports `all(...)` and `any(...)` URL syntax for lists of values as query predicate right-hand side values.
 - `quantified_rid_lists`: Service supports `RID=all(...)` and `RID=any(...)`, a bug-fix to the `quantified_value_lists` feature.
 - `rid_lease`: Service supports `?nondefaults=RID` for POST operations on the `/entity/` API by clients who are not catalog owners. Such use is limited to the rules described for [Entity Creation with Defaults](data/rest.md#entity-creation-with-defaults).
+- `registry_catalog`: Service supports special catalog `0` to introspect the registry, and also supports additional metadata parameters when creating catalogs and creating or updating aliases.
 
 Generally, absence of a feature flag means the service is running
 older software which predates the release of the feature. A flag will
@@ -81,13 +82,23 @@ This method supports an optional JSON input document:
 
     {
       "id": desired catalog id,
-      "owner": administrative ACL
+      "owner": administrative ACL,
+      "name": string,
+      "description": string,
+      "is_persistent": boolean,
+      "clone_source": string
     }
 
 These fields are optional and, if present, override the default behavior obtained in a POST without input:
 
 - `"id"`: The desired _cid_ to bind (default is a service-generated serial number)
 - `"owner"`: Initial owner-level access control list for the new catalog (default is the requesting client's identity)
+- `"name"`: A short, human-readable name or title string for the catalog (default is untitled)
+- `"description"`: A markdown-formatted, human-readable description for the catalog (default is empty)
+- `"is_persistent"`: A boolean. When false, a deployment MAY perform auto-expiry. Supplying a value may be forbidden by policy. (Default is deployment-specific.)
+- `"clone_source"`: An existing catalog ID in the same catalog, to document provenance for clones (catalogs initialized with copied content). Default is empty.
+
+The `name`, `description`, `is_persistent`, and `clone_source` parameters are an extension understood when the service feature-advertisement includes `"registry_catalog": true`. The resulting metadata will then be visible in the corresponding entry in the registy.
 
 On success, this request yields the new catalog identifier, e.g. `42` in this example:
 
@@ -194,6 +205,9 @@ This method supports an optional JSON input document:
       "id": desired alias id,
       "owner": administrative access control list,
       "alias_target": existing storage catalog id
+      "name": string,
+      "description": string,
+      "is_persistent": boolean,
     }
 
 These fields are optional and, if present, override the default behavior obtained in a POST without input:
@@ -201,6 +215,11 @@ These fields are optional and, if present, override the default behavior obtaine
 - `"id"`: The desired _alias_ to bind (default is a service-generated serial number)
 - `"owner"`: Initial access control list for the alias (default is the requesting client's identity)
 - `"alias_target"`: Storage catalog to bind with the new alias (default unbound)
+- `"name"`: A short, human-readable name or title string for the catalog (default is untitled)
+- `"description"`: A markdown-formatted, human-readable description for the catalog (default is empty)
+- `"is_persistent"`: A boolean. When false, a deployment MAY perform auto-expiry. Supplying a value may be forbidden by policy. (Default is deployment-specific.)
+
+The `name`, `description`, and `is_persistent` parameters are an extension understood when the service feature-advertisement includes `"registry_catalog": true`. The resulting metadata will then be visible in the corresponding entry in the registy.
 
 An unbound alias can reserve the alias for future use by clients permitted by the adminstrative access control list.
 

--- a/ermrest/__init__.py
+++ b/ermrest/__init__.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2012-2019 University of Southern California
+# Copyright 2012-2023 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ermrest/catalog.py
+++ b/ermrest/catalog.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2023 University of Southern California
+# Copyright 2013-2024 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ermrest/catalog.py
+++ b/ermrest/catalog.py
@@ -202,6 +202,10 @@ class Catalog (object):
         self.dsn = self._serialize_descriptor(self.descriptor)
         self._factory = factory
         self.alias_target = reg_entry.get('alias_target')
+        self.name = reg_entry.get('name')
+        self.description = reg_entry.get('description')
+        self.is_persistent = reg_entry.get('is_persistent')
+        self.clone_source = reg_entry.get('clone_source')
         self._config = config  # Not sure we need to tuck away the config
 
     def _serialize_descriptor(self, descriptor):

--- a/ermrest/ermrest.wsgi
+++ b/ermrest/ermrest.wsgi
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2012-2013 University of Southern California
+# Copyright 2012-2023 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ermrest/model/column.py
+++ b/ermrest/model/column.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2023 University of Southern California
+# Copyright 2013-2024 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -97,6 +97,14 @@ SELECT _ermrest.model_version_bump();
             return False
         if self.name in {'RID', 'RCB'} and aclname in {'update', 'write'}:
             return False
+        if self.table.name == 'registry' and self.table.schema.name == 'ermrest':
+            if self.name == 'descriptor':
+                return False
+            if self.name in {
+                    'id', 'is_catalog', 'deleted_on',
+                    'owner', 'alias_target',
+            } and aclname in {'insert', 'update', 'write'}:
+                return False
         if self.table.has_right(aclname, roles) is False:
             return False
         return self._has_right(aclname, roles)

--- a/ermrest/model/key.py
+++ b/ermrest/model/key.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2023 University of Southern California
+# Copyright 2013-2024 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -727,7 +727,10 @@ RETURNING fkey_rid;
     def delete(self, conn, cur):
         if self.constraint_name:
             fkr_schema, fkr_name = self.constraint_name
-            idx_name = '_'.join(fkr_name.split('_')[:-1]) + '_idx'
+            # suppress deletion of registry table built-in fkeys
+            if fkr_schema == 'ermrest':
+                if fkr_name in {'registry_alias_target_fkey', 'registry_clone_source_fkey'}:
+                    raise exception.Forbidden('owner access on built-in foreign key')
             self.foreign_key.table.alter_table(
                 conn, cur,
                 'DROP CONSTRAINT %s' % sql_identifier(fkr_name),

--- a/ermrest/model/name.py
+++ b/ermrest/model/name.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2021 University of Southern California
+# Copyright 2013-2023 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ermrest/registry.py
+++ b/ermrest/registry.py
@@ -187,8 +187,10 @@ SELECT jsonb_build_object(
   'deleted_on', CASE WHEN l.alias_target IS NOT NULL THEN t.deleted_on ELSE l.deleted_on END,
   'alias_target', l.alias_target,
   'alias_created_on', CASE WHEN l.alias_target IS NOT NULL THEN l."RCT" ELSE NULL END,
-  'name', CASE WHEN l.alias_target IS NOT NULL THEN t.name ELSE l.name END,
-  'description', CASE WHEN l.alias_target IS NOT NULL THEN t.description ELSE l.description END
+  'name', COALESCE(l.name, t.name),
+  'description', COALESCE(l.description, t.description),
+  'clone_source', l.clone_source,
+  'is_persistent', l.is_persistent
 )
 FROM ermrest.registry l
 LEFT OUTER JOIN ermrest.registry t ON (l.alias_target = t.id)

--- a/ermrest/registry.py
+++ b/ermrest/registry.py
@@ -1,6 +1,6 @@
 
 #
-# Copyright 2012-2023 University of Southern California
+# Copyright 2012-2024 University of Southern California
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ This module defines an abstract base class 'Registry' with one concrete
 implementation 'SimpleRegistry'. The SimpleRegistry is backed by the system
 database owned by the daemon account (typically it is named 'ermrest'). The
 SimpleRegistry depends on the 'ermrest' schema and persists the state of the
-registry in the 'ermrest.simple_registry' table. The base class defines the
+registry in the 'ermrest.registry' table. The base class defines the
 functions supported by this module, and it allows for future implementations
 that may be more sophisticated than the SimpleRegistry implementation.
 """
@@ -159,7 +159,7 @@ class SimpleRegistry(Registry):
             # a limited cost query to test registry DB path
             cur.execute("""
 SELECT count(*)
-FROM ermrest.simple_registry
+FROM ermrest.registry
 WHERE id = '1';
 """)
             if len(list(cur)) == 1:
@@ -173,15 +173,18 @@ WHERE id = '1';
         cur.execute("""
 SELECT jsonb_build_object(
   'id', l.id,
-  'id_owner', l.id_owner,
+  'is_catalog', l.is_catalog,
+  'owner', l.owner,
   'descriptor', CASE WHEN l.alias_target IS NOT NULL THEN t.descriptor ELSE l.descriptor END,
-  'created_on', CASE WHEN l.alias_target IS NOT NULL THEN t.created_on ELSE l.created_on END,
+  'created_on', CASE WHEN l.alias_target IS NOT NULL THEN t."RCT" ELSE l."RCT" END,
   'deleted_on', CASE WHEN l.alias_target IS NOT NULL THEN t.deleted_on ELSE l.deleted_on END,
   'alias_target', l.alias_target,
-  'alias_created_on', CASE WHEN l.alias_target IS NOT NULL THEN l.created_on ELSE NULL END
+  'alias_created_on', CASE WHEN l.alias_target IS NOT NULL THEN l."RCT" ELSE NULL END,
+  'name', CASE WHEN l.alias_target IS NOT NULL THEN t.name ELSE l.name END,
+  'description', CASE WHEN l.alias_target IS NOT NULL THEN t.description ELSE l.description END
 )
-FROM ermrest.simple_registry l
-LEFT OUTER JOIN ermrest.simple_registry t ON (l.alias_target = t.id)
+FROM ermrest.registry l
+LEFT OUTER JOIN ermrest.registry t ON (l.alias_target = t.id)
 WHERE l.deleted_on IS NULL
   AND (l.descriptor IS NOT NULL OR t.descriptor IS NOT NULL OR %(dangling)s::boolean)
   AND (t.id IS NULL OR t.deleted_on IS NULL OR %(dangling)s::boolean)
@@ -199,13 +202,64 @@ WHERE l.deleted_on IS NULL
         :param dangling: List dangling alias entries (default False excludes dangling entries)
 
         There are three forms of resulting entry dict:
-        1. Live catalogs have non-null values for keys {id, id_owner, descriptor, created_on}
+        1. Live catalogs have non-null values for keys {id, owner, descriptor, created_on}
         2. Aliased live augment (1) with non-null values for {alias_target, alias_created_on}
         3. Dangling aliases augment (2) with non-null values for {deleted_on}
         """
         def body(conn, cur):
             return self._lookup(conn, cur, id, dangling)
         return self.pooled_perform(body)
+
+    def _set_webauthn_context(self, cur):
+        """Prepare registry DB connection for mutations on behalf of web client
+
+        Since the registry has become an ERMrest catalog for
+        introspection, we need to fake up the minimal webauthn state
+        needed for provenance metadata tracking of registty changes
+        via the registry APIs, since they are independent of the
+        normal catalog-specific sub-APIs where we already do this.
+        """
+        client = deriva_ctx.webauthn2_context.client
+        if isinstance(client, dict):
+            client_obj = client
+            client = client['id']
+        else:
+            client_obj = { 'id': client }
+
+        attributes = [
+            a['id'] if type(a) is dict else a
+            for a in deriva_ctx.webauthn2_context.attributes
+        ]
+
+        cur.execute("""
+INSERT INTO public."ERMrest_Client" ("ID", "Display_Name", "Full_Name", "Email", "Client_Object")
+VALUES (%(id)s, %(display_name)s, %(full_name)s, %(email)s, %(client_obj)s::jsonb)
+ON CONFLICT ("ID") DO UPDATE
+SET "Display_Name" = excluded."Display_Name",
+    "Full_Name" = excluded."Full_Name",
+    "Email" = excluded."Email",
+    "Client_Object" = excluded."Client_Object";
+""" % {
+    'id': sql_literal(client_obj['id']),
+    'display_name': sql_literal(client_obj.get('display_name')),
+    'full_name': sql_literal(client_obj.get('full_name')),
+    'email': sql_literal(client_obj.get('email')),
+    'client_obj': sql_literal(json.dumps(client_obj)),
+})
+        cur.execute("""
+SELECT set_config('webauthn2.client', %(client)s, false);
+SELECT set_config('webauthn2.client_json', %(client_obj)s, false);
+SELECT set_config('webauthn2.attributes', %(attributes)s, false);
+SELECT set_config('webauthn2.attributes_array', (ARRAY[%(attributes_list)s]::text[])::text, false);
+""" % {
+    'client': sql_literal(client),
+    'client_obj': sql_literal(json.dumps(client_obj)),
+    'attributes': sql_literal(json.dumps(attributes)),
+    'attributes_list': ','.join([
+        sql_literal(attr)
+        for attr in attributes
+    ]),
+})
 
     def claim_id(self, id=None, id_owner=None):
         """Claim and return a distinct catalog identifier.
@@ -224,7 +278,7 @@ WHERE l.deleted_on IS NULL
 
             if id is None:
                 cur.execute("""
-SELECT nextval('ermrest.simple_registry_id_seq');
+SELECT nextval('ermrest.registry_id_seq');
 """)
                 claim_id = cur.fetchone()[0]
             else:
@@ -234,17 +288,18 @@ SELECT nextval('ermrest.simple_registry_id_seq');
             rows = self._lookup(conn, cur, id=claim_id, dangling=True)
             if rows:
                 entry = rows[0]
-                old_id_owner = entry['id_owner'] if entry['id_owner'] else []
+                old_id_owner = entry['owner'] if entry['owner'] else []
                 if set(old_id_owner).isdisjoint(set(deriva_ctx.webauthn2_context.attribute_ids)):
                     raise exception.Forbidden('claim access on entry id=%s' % (id,))
                 if entry['alias_target'] is None and entry['descriptor'] is not None:
                     raise exception.ConflictData('Cannot claim an existing catalog id=%s' % (id,))
 
             # idempotent claim safe if past pre-checks
+            self._set_webauthn_context(cur)
             cur.execute("""
-INSERT INTO ermrest.simple_registry (id, id_owner)
-SELECT %(id)s, ARRAY[%(owner)s]
-ON CONFLICT (id) DO UPDATE SET id_owner = EXCLUDED.id_owner
+INSERT INTO ermrest.registry (id, is_catalog, owner)
+SELECT %(id)s, False, ARRAY[%(owner)s]
+ON CONFLICT (id) DO UPDATE SET owner = EXCLUDED.owner
 RETURNING id;
 """ % {
     'id': sql_literal(claim_id),
@@ -254,27 +309,40 @@ RETURNING id;
 
         return self.pooled_perform(body, lambda x: x)
 
-    def register(self, id, descriptor=None, alias_target=None):
+    def register(self, id, descriptor=None, alias_target=None, name=None, description=None, is_catalog=None):
         """Register a catalog descriptor or alias target for an already claimed id.
 
         :param id: The claimed id.
         :param descriptor: The catalog storage descriptor to register.
         :param alias_target: The id for the target catalog to register.
+        :param name: The name text for the registry entry.
+        :param description: The description text (markdown) for the registry entry.
+        :param is_catalog: True for catalog, false for alias or unbound ID (default: infer)
 
         """
-        assert isinstance(descriptor, dict)
+        assert descriptor is None or isinstance(descriptor, dict)
 
-        if descriptor is not None and alias_target is not None:
-            raise ValueError('cannot register descriptor and alias_target for same entry')
+        if is_catalog is None:
+            is_catalog = descriptor is not None
+
+        if is_catalog:
+            if descriptor is None:
+                raise ValueError('descriptor required when is_catalog=true')
+            if alias_target is not None:
+                raise ValueError('alias_target not allowed when is_catalog=true')
+        else:
+            if descriptor is not None:
+                raise ValueError('descriptor not allowed when is_catalog=true')
 
         def body(conn, cur):
             cur.execute("""
-SELECT 
-  COALESCE(id_owner, ARRAY[]::text[]),
+SELECT
+  COALESCE(owner, ARRAY[]::text[]),
+  is_catalog,
   descriptor,
   alias_target,
   deleted_on
-FROM ermrest.simple_registry
+FROM ermrest.registry
 WHERE id = %(id)s
 """ % {
     'id': sql_literal(id),
@@ -283,31 +351,47 @@ WHERE id = %(id)s
             if row is None:
                 raise exception.ConflictData('Cannot manage registration for unclaimed id=%r.' % (id,))
 
-            id_owner, old_descriptor, old_alias_target, deleted_on = row
+            id_owner, old_is_catalog, old_descriptor, old_alias_target, deleted_on = row
+
             if set(deriva_ctx.webauthn2_context.attribute_ids).isdisjoint(set(id_owner)):
                 raise exception.Forbidden('manage registration for id=%r' % (id,))
 
             if deleted_on is not None:
                 raise exception.ConflictData('Cannot manage registration for deleted entry id=%r.' % (id,))
 
-            if descriptor is not None:
-                if old_descriptor is not None:
-                    raise exception.ConflictData('Catalog descriptor already set for entry id=%r.' % (id,))
-                if old_alias_target is not None:
-                    raise exception.ConflictData('Cannot set descriptor for alias entry id=%r.' % (id,))
-            else:
-                if old_descriptor is not None:
-                    raise exception.ConflictData('Cannot set alias_target for catalog entry id=%r.' % (id,))
-
-            cur.execute("""
-UPDATE ermrest.simple_registry v
-SET descriptor = %(descriptor)s,
-    alias_target = %(alias_target)s
+            self._set_webauthn_context(cur)
+            if old_is_catalog:
+                if descriptor is not None:
+                    raise exception.ConflictData('Cannot set descriptor on existing catalog id=%r.' % (id,))
+                if alias_target is not None:
+                    raise exception.ConflictData('Cannot set alias_target on existing catalog id=%r.' % (id,))
+                cur.execute("""
+UPDATE ermrest.registry v
+SET "name" = %(name)s,
+    description = %(description)s
 WHERE id = %(id)s;
 """ % {
     'id': sql_literal(id),
+    'name': sql_literal(name),
+    'description': sql_literal(description),
+})
+            else:
+                # earlier checks validated is_catalog/descriptor/alias_target args
+                cur.execute("""
+UPDATE ermrest.registry v
+SET is_catalog = %(is_catalog)s,
+    descriptor = %(descriptor)s,
+    alias_target = %(alias_target)s,
+    "name" = %(name)s,
+    description = %(description)s
+WHERE id = %(id)s;
+""" % {
+    'id': sql_literal(id),
+    'is_catalog': sql_literal(is_catalog),
     'descriptor': sql_literal(json.dumps(descriptor)),
     'alias_target': sql_literal(alias_target),
+    'name': sql_literal(name),
+    'description': sql_literal(description),
 })
             return self._lookup(conn, cur, id)[0]
 
@@ -322,15 +406,16 @@ WHERE id = %(id)s;
 
         def body(conn, cur):
             """Returns True if row deleted, false if not"""
+            self._set_webauthn_context(cur)
             cur.execute("""
 WITH deleted_alias AS (
-  DELETE FROM ermrest.simple_registry
+  DELETE FROM ermrest.registry
   WHERE id = %(id)s
     AND descriptor IS NULL
     AND deleted_on IS NULL
   RETURNING id
 ), softdeleted_catalog AS (
-  UPDATE ermrest.simple_registry
+  UPDATE ermrest.registry
   SET deleted_on = current_timestamp
   WHERE id = %(id)s
     AND deleted_on IS NULL

--- a/ermrest/sql/ermrest_schema.sql
+++ b/ermrest/sql/ermrest_schema.sql
@@ -1,6 +1,6 @@
 
 -- 
--- Copyright 2012-2023 University of Southern California
+-- Copyright 2012-2024 University of Southern California
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/ermrest/sql/ermrest_schema.sql
+++ b/ermrest/sql/ermrest_schema.sql
@@ -724,6 +724,18 @@ CREATE OR REPLACE FUNCTION _ermrest.find_column_rid(sname text, tname text, cnam
   WHERE s.schema_name = $1 AND t.table_name = $2 AND c.column_name = $3;
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION _ermrest.find_key_rid(sname text, constraintname text) RETURNS text AS $$
+  SELECT k."RID" FROM _ermrest.known_keys k
+  WHERE schema_rid = _ermrest.find_schema_rid($1)
+    AND constraint_name = $2;
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION _ermrest.find_fkey_rid(sname text, constraintname text) RETURNS text AS $$
+  SELECT fk."RID" FROM _ermrest.known_fkeys fk
+  WHERE schema_rid = _ermrest.find_schema_rid($1)
+    AND constraint_name = $2;
+$$ LANGUAGE SQL;
+
 CREATE OR REPLACE VIEW _ermrest.introspect_schemas AS
   SELECT
     nc.oid,

--- a/ermrest/sql/registry.sql
+++ b/ermrest/sql/registry.sql
@@ -92,13 +92,21 @@ SELECT _ermrest.model_change_event();
 
 -- HACK: all entries can be listed by public?
 INSERT INTO _ermrest.known_table_acls (table_rid, acl, members) VALUES
-  (_ermrest.find_table_rid('ermrest', 'registry'), 'select', ARRAY['*']::text[])
+  (_ermrest.find_table_rid('ermrest', 'registry'), 'select', ARRAY['*']::text[]),
+  (_ermrest.find_table_rid('public', 'ERMrest_Client'), 'select', ARRAY['*']::text[])
   ON CONFLICT DO NOTHING;
 
--- NOTE: hide descriptor column which could leak internal ops data
+-- hide columns that could leak internal operational info
 INSERT INTO _ermrest.known_column_acls (column_rid, acl, members) VALUES
   (_ermrest.find_column_rid('ermrest', 'registry', 'descriptor'), 'enumerate', ARRAY[]::text[]),
-  (_ermrest.find_column_rid('ermrest', 'registry', 'descriptor'), 'select', ARRAY[]::text[])
+  (_ermrest.find_column_rid('ermrest', 'registry', 'descriptor'), 'select', ARRAY[]::text[]),
+  (_ermrest.find_column_rid('ermrest', 'registry', 'owner'), 'select', ARRAY[]::text[]),
+  (_ermrest.find_column_rid('public', 'ERMrest_Client', 'Email'), 'enumerate', ARRAY[]::text[]),
+  (_ermrest.find_column_rid('public', 'ERMrest_Client', 'Email'), 'select', ARRAY[]::text[]),
+  (_ermrest.find_column_rid('public', 'ERMrest_Client', 'Client_Object'), 'enumerate', ARRAY[]::text[]),
+  (_ermrest.find_column_rid('public', 'ERMrest_Client', 'Client_Object'), 'select', ARRAY[]::text[]),
+  (_ermrest.find_column_rid('public', 'ERMrest_Client', 'Full_Name'), 'enumerate', ARRAY[]::text[]),
+  (_ermrest.find_column_rid('public', 'ERMrest_Client', 'Full_Name'), 'select', ARRAY[]::text[])
   ON CONFLICT DO NOTHING;
 
 -- allow entry owners to do basic editing of their entries
@@ -115,6 +123,285 @@ INSERT INTO _ermrest.known_column_dynacls (column_rid, binding_name, binding)
     AND column_name NOT IN ('name', 'description', 'clone_source', 'is_persistent')
   ON CONFLICT DO NOTHING;
 
-CREATE INDEX IF NOT EXISTS registry_deleted_on_idx    ON ermrest.registry (deleted_on);
-CREATE INDEX IF NOT EXISTS registry_id_notdeleted_idx ON ermrest.registry (id) WHERE deleted_on IS NULL;
-CREATE INDEX IF NOT EXISTS registry_id_target_notdeleted_idx ON ermrest.registry (id, alias_target) WHERE deleted_on IS NULL;
+INSERT INTO _ermrest.known_column_dynacls (column_rid, binding_name, binding) VALUES
+  (_ermrest.find_column_rid('ermrest', 'registry', 'owner'), 'view_by_owner',
+   '{"types": ["select"], "projection": ["owner"], "projection_type": "acl", "scope_acl": ["*"]}'::jsonb)
+  ON CONFLICT DO NOTHING;
+
+-- SET DEFAULT PRESENTATION HINTS
+INSERT INTO _ermrest.known_catalog_annotations (annotation_uri, annotation_value) VALUES
+  ( 'tag:isrd.isi.edu,2019:chaise-config',
+    $${
+      "defaultTable": {
+        "schema": "ermrest",
+        "table": "registry"
+      },
+      "displayDefaultExport": false
+    }$$::jsonb
+  )
+  ON CONFLICT DO NOTHING;
+
+INSERT INTO _ermrest.known_schema_annotations (schema_rid, annotation_uri, annotation_value) VALUES
+  ( _ermrest.find_schema_rid('ermrest'),
+    'tag:misd.isi.edu,2015:display',
+    $${
+      "name_style": {
+        "underline_space": true,
+        "title_case": true
+      }
+    }$$::jsonb
+  ),
+  ( _ermrest.find_schema_rid('public'),
+    'tag:misd.isi.edu,2015:display',
+    $${
+      "name_style": {
+        "underline_space": true,
+        "title_case": true
+      }
+    }$$::jsonb
+  )
+  ON CONFLICT DO NOTHING;
+
+INSERT INTO _ermrest.known_table_annotations (table_rid, annotation_uri, annotation_value) VALUES
+  ( _ermrest.find_table_rid('public', 'ERMrest_Client'),
+    'tag:isrd.isi.edu,2016:table-display',
+    $${
+        "row_name": {
+          "row_markdown_pattern": "{{{Display_Name}}}"
+        }
+    }$$::jsonb
+  ),
+  ( _ermrest.find_table_rid('ermrest', 'registry'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "ERMrest Registry" }$$
+  ),
+   ( _ermrest.find_table_rid('ermrest', 'registry'),
+    'tag:isrd.isi.edu,2019:source-definitions',
+    $${
+        "columns": true,
+        "sources": {
+          "S_RCB": {
+            "source": [{"outbound": ["ermrest", "registry_rcb_fkey"]}, "RID"],
+            "comment": "Client who created this entry"
+          },
+          "S_RMB": {
+            "source": [{"outbound": ["ermrest", "registry_rmb_fkey"]}, "RID"],
+            "comment": "Client who last modified this entry"
+          },
+          "S_clone_source": {
+            "source": [{"outbound": ["ermrest", "registry_clone_source_fkey"]}, "RID"],
+            "comment": "Catalog from which content was copied"
+          },
+          "S_alias_target": {
+            "source": [{"outbound": ["ermrest", "registry_alias_target_fkey"]}, "RID"],
+            "comment": "Catalog to which the alias entry resolves"
+          },
+          "S_aliases": {
+            "source": [{"inbound": ["ermrest", "registry_alias_target_fkey"]}, "RID"],
+            "comment": "Alias entries resolving to this catalog"
+          },
+          "S_clones": {
+            "source": [{"inbound": ["ermrest", "registry_clone_source_fkey"]}, "RID"],
+            "comment": "Catalogs with content copied from this catalog"
+          }
+        }
+    }$$
+  ),
+  ( _ermrest.find_table_rid('ermrest', 'registry'),
+    'tag:isrd.isi.edu,2016:visible-columns',
+    $${
+        "compact": [
+          "id",
+          {
+            "markdown_name": "Description",
+            "comment": "Name and description content",
+            "display": {
+              "template_engine": "handlebars",
+              "markdown_pattern": "{{#if name}}#### {{{name}}} \n{{/if}}{{#if description}}{{{description}}}{{/if}}"
+            }
+          },
+          {
+            "markdown_name": "Status",
+            "comment": "Status or mode of registry entry",
+            "display": {
+              "template_engine": "handlebars",
+              "markdown_pattern": "{{#if _is_catalog}}{{#if _deleted_on}}Soft-deleted{{else}}{{#if _is_persistent}}Persistent{{else}}Ephemeral{{/if}}{{/if}} database{{#if clone_source}}\nClone of: {{{clone_source}}}{{/if}}{{else}}{{#if alias_target}}Alias for: {{{alias_target}}}{{else}}Reserved identifier{{/if}}{{/if}}"
+            }
+          },
+          "RCT"
+        ],
+        "*": [
+          "id",
+          "name",
+          "description",
+          "is_catalog",
+          "is_persistent",
+          {"sourcekey": "S_alias_target"},
+          {"sourcekey": "S_clone_source"},
+          "owner",
+          "RCT",
+          {"sourcekey": "S_RCB"},
+          "RMT",
+          {"sourcekey": "S_RMB"},
+          "deleted_on"
+        ],
+        "entry": [
+          "id",
+          "is_catalog",
+          "is_persistent",
+          {"sourcekey": "S_clone_source"},
+          "name",
+          "description"
+        ],
+        "filter": { "and": [
+          {
+            "markdown_name": "Has Name?",
+            "comment": "Is the entry name field populated?",
+            "source": "name",
+            "ux_mode": "check_presence"
+          },
+          {
+            "markdown_name": "Has Description?",
+            "comment": "Is the entry description field populated?",
+            "source": "description",
+            "ux_mode": "check_presence"
+          },
+          {"source": "is_catalog"},
+          {"source": "is_persistent"},
+          {
+            "markdown_name": "Is Deleted?",
+            "comment": "Is the entry marked as deleted?",
+            "source": "deleted_on",
+            "ux_mode": "check_presence"
+          },
+          {"sourcekey": "S_alias_target"},
+          {
+            "markdown_name": "Has Aliases?",
+            "comment": "Is the entry referenced as an alias target?",
+            "sourcekey": "S_aliases",
+            "ux_mode": "check_presence"
+          },
+          {"sourcekey": "S_clone_source"},
+          {
+            "markdown_name": "Has Clones?",
+            "comment": "Is the entry referenced as a clone source?",
+            "sourcekey": "S_clones",
+            "ux_mode": "check_presence"
+          },
+          {"source": "RCT"},
+          {"sourcekey": "S_RCB"},
+          {"source": "RMT"},
+          {"sourcekey": "S_RMB"},
+          {"source": "deleted_on"}
+        ]}
+    }$$::jsonb
+  ),
+  ( _ermrest.find_table_rid('ermrest', 'registry'),
+    'tag:isrd.isi.edu,2016:visible-foreign-keys',
+    $${
+         "*": [
+           {"sourcekey": "S_aliases"},
+           {"sourcekey": "S_clones"}
+         ]
+    }$$
+  )
+  ON CONFLICT DO NOTHING;
+
+INSERT INTO _ermrest.known_column_annotations (column_rid, annotation_uri, annotation_value) VALUES
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'RCT'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "Creation Time" }$$
+  ),
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'RMT'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "Last Modified Time" }$$
+  ),
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'RMB'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "Last Modified By" }$$
+  ),
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'id'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "ID" }$$
+  ),
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'id'),
+    'tag:isrd.isi.edu,2016:column-display',
+    $${
+      "*": {
+        "template_engine": "handlebars",
+        "markdown_pattern": "[{{{id}}}](/chaise/recordset/#{{#encode _id}}{{/encode}})"
+      }
+    }$$
+  ),
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'name'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "Name" }$$
+  ),
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'description'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "Description" }$$
+  ),
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'deleted_on'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "Deletion Time" }$$
+  ),
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'owner'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "Owner ACL" }$$
+  ),
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'is_catalog'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "Is Catalog?" }$$
+  ),
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'clone_source'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "Clone Source" }$$
+  ),
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'alias_target'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "Alias Target" }$$
+  ),
+  ( _ermrest.find_column_rid('ermrest', 'registry', 'is_persistent'),
+    'tag:misd.isi.edu,2015:display',
+    $${ "name": "Is Persistent?" }$$
+  )
+  ON CONFLICT DO NOTHING;
+
+INSERT INTO _ermrest.known_fkey_annotations (fkey_rid, annotation_uri, annotation_value) VALUES
+  ( _ermrest.find_fkey_rid('ermrest', 'registry_clone_source_fkey'),
+    'tag:isrd.isi.edu,2016:foreign-key',
+    $${
+        "to_name": "Clone Source",
+        "to_comment": "Catalog from which content was copied",
+        "from_name": "Clone",
+        "from_comment": "Catalog to which content was copied"
+    }$$
+  ),
+  ( _ermrest.find_fkey_rid('ermrest', 'registry_alias_target_fkey'),
+    'tag:isrd.isi.edu,2016:foreign-key',
+    $${
+        "to_name": "Alias Target",
+        "to_comment": "Catalog to which this alias entry resolves",
+        "from_name": "Alias",
+        "from_comment": "Alias entry resolving to this catalog"
+    }$$
+  ),
+  ( _ermrest.find_fkey_rid('ermrest', 'registry_rcb_fkey'),
+    'tag:isrd.isi.edu,2016:foreign-key',
+    $${
+        "to_name": "Created By",
+        "to_comment": "Client who created this entry",
+        "from_name": "Created Registry Entry",
+        "from_comment": "Registry entry created by this client"
+    }$$
+  ),
+  ( _ermrest.find_fkey_rid('ermrest', 'registry_rmb_fkey'),
+    'tag:isrd.isi.edu,2016:foreign-key',
+    $${
+        "to_name": "Last Modified By",
+        "to_comment": "Client who last modified this entry",
+        "from_name": "Last Modified Registry Entry",
+        "from_comment": "Registry entry last modified by this client"
+    }$$
+  )
+  ON CONFLICT DO NOTHING;

--- a/ermrest/sql/registry.sql
+++ b/ermrest/sql/registry.sql
@@ -1,6 +1,6 @@
 
 -- 
--- Copyright 2012-2021 University of Southern California
+-- Copyright 2012-2024 University of Southern California
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -17,56 +17,85 @@
 
 CREATE SCHEMA IF NOT EXISTS ermrest;
 
-CREATE SEQUENCE IF NOT EXISTS ermrest.simple_registry_id_seq;
+CREATE SEQUENCE IF NOT EXISTS ermrest.registry_id_seq;
 
-CREATE TABLE IF NOT EXISTS ermrest.simple_registry (
-  id text PRIMARY KEY DEFAULT (nextval('ermrest.simple_registry_id_seq')::text),
-  id_owner text[],
+CREATE TABLE IF NOT EXISTS ermrest.registry (
+  "RID" ermrest_rid UNIQUE NOT NULL DEFAULT (_ermrest.urlb32_encode(nextval('_ermrest.rid_seq'))),
+  "RCT" ermrest_rct NOT NULL DEFAULT (now()),
+  "RMT" ermrest_rmt NOT NULL DEFAULT (now()),
+  "RCB" ermrest_rcb DEFAULT (_ermrest.current_client()),
+  "RMB" ermrest_rmb DEFAULT (_ermrest.current_client()),
+  id text PRIMARY KEY DEFAULT (nextval('ermrest.registry_id_seq')::text),
+  is_catalog boolean NOT NULL DEFAULT True,
+  deleted_on timestamp with time zone DEFAULT NULL,
+  owner text[],
   descriptor jsonb,
   alias_target text,
-  created_on timestamp with time zone DEFAULT (now()),
-  deleted_on timestamp with time zone DEFAULT NULL,
-  CONSTRAINT simple_registry_alias_target_fkey
-    FOREIGN KEY (alias_target) REFERENCES ermrest.simple_registry(id)
-    ON UPDATE CASCADE ON DELETE SET NULL
+  clone_source text,
+  "name" text,
+  description markdown,
+  CONSTRAINT registry_catalog_needs_descriptor
+    CHECK ((NOT is_catalog) OR (descriptor IS NOT NULL)),
+  CONSTRAINT registry_catalog_blocks_alias_target
+    CHECK ((NOT is_catalog) OR (alias_target IS NULL)),
+  CONSTRAINT registry_alias_blocks_clone_source
+    CHECK (is_catalog OR (clone_source IS NULL)),
+  CONSTRAINT registry_alias_target_fkey
+    FOREIGN KEY (alias_target) REFERENCES ermrest.registry(id)
+    ON UPDATE CASCADE ON DELETE SET NULL,
+  CONSTRAINT registry_clone_source_fkey
+    FOREIGN KEY (clone_source) REFERENCES ermrest.registry(id)
+    ON UPDATE CASCADE ON DELETE SET NULL,
+  CONSTRAINT registry_rcb_fkey
+    FOREIGN KEY ("RCB") REFERENCES public."ERMrest_Client"("ID")
+    ON UPDATE CASCADE ON DELETE NO ACTION,
+  CONSTRAINT registry_rmb_fkey
+    FOREIGN KEY ("RMB") REFERENCES public."ERMrest_Client"("ID")
+    ON UPDATE CASCADE ON DELETE NO ACTION
 );
 
-DO $$
-BEGIN
+-- ADD SELF-REFERENCE
+INSERT INTO ermrest.registry ("RCT", "RMT", id, is_catalog, owner, descriptor, "name", description) VALUES
+  (now(), now(), '0', True, ARRAY[]::text[], '{"dbname":"ermrest"}', 'ERMrest Registry', 'Tracking database for all dynamically provisioned ERMrest catalogs.')
+  ON CONFLICT DO NOTHING;
 
-IF (SELECT True
-    FROM information_schema.columns
-    WHERE table_schema = 'ermrest'
-      AND table_name = 'simple_registry'
-      AND column_name = 'created_on') IS NULL THEN
-      
-  -- add provenance column to legacy deployments
-  ALTER TABLE ermrest.simple_registry
-    ADD COLUMN created_on timestamp with time zone DEFAULT (now());
-END IF;
+-- SET DEFAULT POLICY
+INSERT INTO _ermrest.known_catalog_acls (acl, members) VALUES
+  ('enumerate', ARRAY['*']::text[]),
+  ('owner', ARRAY[]::text[]),
+  ('select', ARRAY[]::text[]),
+  ('insert', ARRAY[]::text[]),
+  ('update', ARRAY[]::text[]),
+  ('delete', ARRAY[]::text[])
+  ON CONFLICT DO NOTHING;
 
-IF (SELECT True
-    FROM information_schema.columns
-    WHERE table_schema = 'ermrest'
-      AND table_name = 'simple_registry'
-      AND column_name = 'alias_target') IS NULL THEN
+SELECT _ermrest.model_change_event();
 
-  -- perform catalog naming feature upgrade
-  ALTER TABLE ermrest.simple_registry
-    ALTER COLUMN id TYPE text,
-    ALTER COLUMN descriptor TYPE jsonb USING (descriptor::jsonb),
-    ADD COLUMN id_owner text[],
-    ADD COLUMN alias_target text,
-    ADD CONSTRAINT simple_registry_alias_target_fkey
-      FOREIGN KEY (alias_target) REFERENCES ermrest.simple_registry(id)
-      ON UPDATE CASCADE ON DELETE SET NULL;
+-- HACK: all entries can be listed by public?
+INSERT INTO _ermrest.known_table_acls (table_rid, acl, members) VALUES
+  (_ermrest.find_table_rid('ermrest', 'registry'), 'select', ARRAY['*']::text[])
+  ON CONFLICT DO NOTHING;
 
-END IF;
+-- NOTE: hide descriptor column which could leak internal ops data
+INSERT INTO _ermrest.known_column_acls (column_rid, acl, members) VALUES
+  (_ermrest.find_column_rid('ermrest', 'registry', 'descriptor'), 'enumerate', ARRAY[]::text[]),
+  (_ermrest.find_column_rid('ermrest', 'registry', 'descriptor'), 'select', ARRAY[]::text[])
+  ON CONFLICT DO NOTHING;
 
-END;
-$$ LANGUAGE plpgsql;
+-- allow entry owners to do basic editing of their entries
+INSERT INTO _ermrest.known_table_dynacls (table_rid, binding_name, binding) VALUES
+  (_ermrest.find_table_rid('ermrest', 'registry'), 'update_by_owner',
+   '{"types": ["update"], "projection": ["owner"], "projection_type": "acl", "scope_acl": ["*"]}'::jsonb)
+  ON CONFLICT DO NOTHING;
 
-CREATE INDEX IF NOT EXISTS simple_registry_deleted_on_idx    ON ermrest.simple_registry (deleted_on);
-CREATE INDEX IF NOT EXISTS simple_registry_created_on_idx    ON ermrest.simple_registry (created_on);
-CREATE INDEX IF NOT EXISTS simple_registry_id_notdeleted_idx ON ermrest.simple_registry (id) WHERE deleted_on IS NULL;
-CREATE INDEX IF NOT EXISTS simple_registry_id_target_notdeleted_idx ON ermrest.simple_registry (id, alias_target) WHERE deleted_on IS NULL;
+-- suppress owner-based editing for most columns
+INSERT INTO _ermrest.known_column_dynacls (column_rid, binding_name, binding)
+  SELECT "RID", 'update_by_owner', 'false'::jsonb
+  FROM _ermrest.known_columns
+  WHERE table_rid = _ermrest.find_table_rid('ermrest', 'registry')
+    AND column_name NOT IN ('name', 'description', 'clone_source')
+  ON CONFLICT DO NOTHING;
+
+CREATE INDEX IF NOT EXISTS registry_deleted_on_idx    ON ermrest.registry (deleted_on);
+CREATE INDEX IF NOT EXISTS registry_id_notdeleted_idx ON ermrest.registry (id) WHERE deleted_on IS NULL;
+CREATE INDEX IF NOT EXISTS registry_id_target_notdeleted_idx ON ermrest.registry (id, alias_target) WHERE deleted_on IS NULL;

--- a/ermrest/sql/upgrade_registry.sql
+++ b/ermrest/sql/upgrade_registry.sql
@@ -28,17 +28,15 @@ IF (SELECT True
 
   PERFORM setval('ermrest.registry_id_seq', nextval('ermrest.simple_registry_id_seq'));
 
-  INSERT INTO ermrest.registry ("RCT", "RMT", "RCB", "RMB", id, is_catalog, deleted_on, owner, descriptor, alias_target)
+  INSERT INTO ermrest.registry ("RCT", "RMT", id, is_catalog, deleted_on, owner, descriptor, alias_target)
   SELECT
     COALESCE(created_on, now()),
     now(),
-    id_owner[1],
-    id_owner[1],
     id,
-    descriptor IS NOT NULL,
+    descriptor IS NOT NULL AND descriptor != 'null'::jsonb,
     deleted_on,
     id_owner,
-    descriptor,
+    CASE WHEN descriptor = 'null'::jsonb THEN NULL::jsonb ELSE descriptor END,
     alias_target
   FROM ermrest.simple_registry
   ;

--- a/ermrest/sql/upgrade_registry.sql
+++ b/ermrest/sql/upgrade_registry.sql
@@ -42,7 +42,7 @@ IF (SELECT True
   ;
 
   DROP TABLE ermrest.simple_registry;
-  DROP SEQUENCE ermrest.simple_registry_id_seq;
+  DROP SEQUENCE IF EXISTS ermrest.simple_registry_id_seq;
 
 END IF;
 

--- a/ermrest/sql/util.py
+++ b/ermrest/sql/util.py
@@ -1,6 +1,6 @@
 
 #
-# Copyright 2017-2023 University of Southern California
+# Copyright 2017-2024 University of Southern California
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ermrest/sql/util.py
+++ b/ermrest/sql/util.py
@@ -98,13 +98,20 @@ def print_redeploy_registry_sql():
 \\connect ermrest
 BEGIN;
 ALTER DATABASE ermrest OWNER TO ermrest;
+%(ermrest_sql)s
+SELECT _ermrest.model_change_event();
 %(registry_sql)s
-%(upgrade_sql)s
 %(change_owners_sql)s
+COMMIT;
+-- commit here in case a DB admin needs to intervene in a failed upgrade
+BEGIN;
+%(upgrade_sql)s
+SELECT _ermrest.model_change_event();
 COMMIT;
 ANALYZE;
 """ % {
     "template1_extupgrade": extupgrade_sql('template1'),
+    "ermrest_sql": pkgutil.get_data(sql.__name__, 'ermrest_schema.sql').decode(),
     "registry_sql": pkgutil.get_data(sql.__name__, 'registry.sql').decode(),
     "upgrade_sql": pkgutil.get_data(sql.__name__, 'upgrade_registry.sql').decode(),
     "change_owners_sql": pkgutil.get_data(sql.__name__, 'change_owner.sql').decode(),
@@ -125,6 +132,7 @@ ALTER DATABASE %(dbname)s OWNER TO ermrest;
 %(ermrest_sql)s
 SELECT _ermrest.model_change_event();
 %(upgrade_sql)s
+SELECT _ermrest.model_change_event();
 %(change_owners_sql)s
 COMMIT;
 ANALYZE;

--- a/ermrest/url/ast/catalog.py
+++ b/ermrest/url/ast/catalog.py
@@ -116,7 +116,10 @@ class Catalogs (object):
         # register the catalog descriptor
         entry = deriva_ctx.ermrest_registry.register(
             catalog_id, is_catalog=True, descriptor=catalog.descriptor,
-            name=doc.get('name'), description=doc.get('description'),
+            name=doc.get('name', deriva_ctx.ermrest_registry.nochange),
+            description=doc.get('description', deriva_ctx.ermrest_registry.nochange),
+            is_persistent=doc.get('is_persistent', deriva_ctx.ermrest_registry.nochange),
+            clone_source=doc.get('clone_source', deriva_ctx.ermrest_registry.nochange),
         )
 
         deriva_ctx.deriva_response.content_type = content_type
@@ -167,8 +170,11 @@ class CatalogAliases (object):
 
         # register the catalog descriptor
         entry = deriva_ctx.ermrest_registry.register(
-            catalog_id, is_catalog=False, alias_target=doc.get('alias_target'),
-            name=doc.get('name'), description=doc.get('description'),
+            catalog_id, is_catalog=False,
+            alias_target=doc.get('alias_target', deriva_ctx.ermrest_registry.nochange),
+            name=doc.get('name'),
+            description=doc.get('description'),
+            is_persistent=doc.get('is_persistent', deriva_ctx.ermrest_registry.nochange),
         )
 
         location = '/ermrest/catalog/%s' % catalog_id

--- a/ermrest/url/ast/catalog.py
+++ b/ermrest/url/ast/catalog.py
@@ -311,6 +311,14 @@ class Catalog (Api):
             resource["id"] = self.catalog_id
             if self.manager.alias_target is not None:
                 resource["alias_target"] = self.manager.alias_target
+            if self.manager.name is not None:
+                resource["name"] = self.manager.name
+            if self.manager.description is not None:
+                resource["description"] = self.manager.description
+            if self.manager.is_persistent is not None:
+                resource["is_persistent"] = self.manager.is_persistent
+            if self.manager.clone_source is not None:
+                resource["clone_source"] = self.manager.clone_source
             if self.catalog_amendver:
                 self.set_http_etag( '%s-%s' % (self.catalog_snaptime, self.catalog_amendver) )
             else:

--- a/ermrest/url/ast/catalog.py
+++ b/ermrest/url/ast/catalog.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2010-2023 University of Southern California
+# Copyright 2010-2024 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -114,7 +114,10 @@ class Catalogs (object):
             pc.final()
 
         # register the catalog descriptor
-        entry = deriva_ctx.ermrest_registry.register(catalog_id, descriptor=catalog.descriptor)
+        entry = deriva_ctx.ermrest_registry.register(
+            catalog_id, is_catalog=True, descriptor=catalog.descriptor,
+            name=doc.get('name'), description=doc.get('description'),
+        )
 
         deriva_ctx.deriva_response.content_type = content_type
         deriva_ctx.ermrest_request_content_type = content_type
@@ -163,7 +166,10 @@ class CatalogAliases (object):
         catalog_id = deriva_ctx.ermrest_registry.claim_id(id=doc.get('id'), id_owner=doc.get('owner'))
 
         # register the catalog descriptor
-        entry = deriva_ctx.ermrest_registry.register(catalog_id, alias_target=doc.get('alias_target'))
+        entry = deriva_ctx.ermrest_registry.register(
+            catalog_id, is_catalog=False, alias_target=doc.get('alias_target'),
+            name=doc.get('name'), description=doc.get('description'),
+        )
 
         location = '/ermrest/catalog/%s' % catalog_id
         deriva_ctx.deriva_response.content_type = content_type
@@ -396,7 +402,7 @@ class CatalogAlias (ApiBase):
         if version is None:
             normalized = [
                 self.entry['id'],
-                self.entry['id_owner'],
+                self.entry['owner'],
                 self.entry['alias_target'],
             ]
             version = base64.urlsafe_b64encode(hashlib.md5(json.dumps(normalized).encode('utf8')).digest()).decode()
@@ -404,8 +410,8 @@ class CatalogAlias (ApiBase):
 
     @property
     def id_owner(self):
-        if isinstance(self.entry['id_owner'], list):
-            return self.entry['id_owner']
+        if isinstance(self.entry['owner'], list):
+            return self.entry['owner']
         else:
             return []
 
@@ -419,7 +425,7 @@ class CatalogAlias (ApiBase):
     def prejson(self):
         return {
             'id': self.entry['id'],
-            'owner': self.entry['id_owner'],
+            'owner': self.entry['owner'],
             'alias_target': self.entry['alias_target'],
         }
 
@@ -467,13 +473,13 @@ class CatalogAlias (ApiBase):
         catalog_id = deriva_ctx.ermrest_registry.claim_id(id=catalog_id, id_owner=doc.get('owner'))
 
         # update the alias config
-        entry = deriva_ctx.ermrest_registry.register(catalog_id, alias_target=doc.get('alias_target'))
+        entry = deriva_ctx.ermrest_registry.register(catalog_id, is_catalog=False, alias_target=doc.get('alias_target'))
 
         content_type = _application_json
         deriva_ctx.ermrest_request_content_type = content_type
         response = json.dumps({
             'id': entry['id'],
-            'owner': entry['id_owner'],
+            'owner': entry['owner'],
             'alias_target': entry['alias_target'],
         }) + '\n'
 

--- a/ermrest/url/ast/data/path.py
+++ b/ermrest/url/ast/data/path.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2016 University of Southern California
+# Copyright 2013-2017 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -1,5 +1,5 @@
 # 
-# Copyright 2012-2023 University of Southern California
+# Copyright 2012-2024 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -149,6 +149,7 @@ def service_features():
         "quantified_value_lists": True,
         "quantified_rid_lists": True,
         "rid_lease": True,
+        "registry_catalog": True,
     }
 
 class OrderedFrozenSet (collections.abc.Set):

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -25,7 +25,7 @@ import base64
 import collections
 from webauthn2.util import urlquote
 
-__version__ = '0.4.1'
+__version__ = '0.5.0'
 
 def urlunquote(url):
     text = urllib.parse.unquote_plus(url)

--- a/sbin/ermrest-deploy
+++ b/sbin/ermrest-deploy
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 
-# Copyright 2012-2017 University of Southern California
+# Copyright 2012-2019 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sbin/ermrest-registry-purge
+++ b/sbin/ermrest-registry-purge
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 
-# Copyright 2012-2015 University of Southern California
+# Copyright 2012-2024 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -92,11 +92,11 @@ if [ -n "${ALL}" -a -n "${INTERVAL}" ]; then
 fi
 
 # Generate query statement
-QUERY="SELECT id, descriptor::json->'dbname' FROM ermrest.simple_registry"
+QUERY="SELECT id, descriptor::json->'dbname' FROM ermrest.registry WHERE id != '0'"
 if [ -n "${INTERVAL}" ]; then
-    QUERY="${QUERY} WHERE deleted_on < (CURRENT_TIMESTAMP - interval '${INTERVAL}')"
+    QUERY="${QUERY} AND deleted_on < (CURRENT_TIMESTAMP - interval '${INTERVAL}')"
 elif [ -z "${ALL}" ]; then
-    QUERY="${QUERY} WHERE deleted_on IS NOT NULL"
+    QUERY="${QUERY} AND deleted_on IS NOT NULL"
 fi
 
 # For all selected catalogs, attempt to dropdb and delete from registry
@@ -155,7 +155,7 @@ EOF
     fi
 
     # delete registry entry of catalog
-    psql -q -c "DELETE FROM ermrest.simple_registry WHERE id = '${id}'" ${ERMREST}
+    psql -q -c "DELETE FROM ermrest.registry WHERE id = '${id}'" ${ERMREST}
     if [ $? -ne 0 ]; then
         log " DELETE FAILED\n"
         continue

--- a/test/ermrest-registry-purge-tests.sh
+++ b/test/ermrest-registry-purge-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 
-# Copyright 2012-2017 University of Southern California
+# Copyright 2012-2024 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/ermrest-registry-purge-tests.sh
+++ b/test/ermrest-registry-purge-tests.sh
@@ -91,7 +91,7 @@ EOF
 
 # Output the count of catalogs in registry
 function count_catalogs {
-    su -c "psql -A -t -q -c \"select count(*) from ermrest.registry\" ${MASTERDB}" - "${DAEMONUSER}"
+    su -c "psql -A -t -q -c \"select count(*) from ermrest.registry where id!='0'\" ${MASTERDB}" - "${DAEMONUSER}"
 }
 
 # Setup a few catalogs (with dbs) for different conditions

--- a/test/ermrest-registry-purge-tests.sh
+++ b/test/ermrest-registry-purge-tests.sh
@@ -76,7 +76,7 @@ function verbose {
     fi
 }
 
-# Add a catalog entry to the simple_registry
+# Add a catalog entry to the registry
 #   dbn: name of the database
 #   when: postgres timestamptz of deleted_on (default = NULL)
 function register_catalog {
@@ -84,14 +84,14 @@ function register_catalog {
     local when=$2
     verbose "Registering catalog for ${dbn} with deleted_on = ${when}"
     su -c "psql -q \"${MASTERDB}\"" - "${DAEMONUSER}" >>${LOG} 2>&1 <<EOF
-INSERT INTO ermrest.simple_registry ("descriptor", "deleted_on")
+INSERT INTO ermrest.registry ("descriptor", "deleted_on")
 VALUES ('{ "dbname": "${dbn}" }', ${when});
 EOF
 }
 
 # Output the count of catalogs in registry
 function count_catalogs {
-    su -c "psql -A -t -q -c \"select count(*) from ermrest.simple_registry\" ${MASTERDB}" - "${DAEMONUSER}"
+    su -c "psql -A -t -q -c \"select count(*) from ermrest.registry\" ${MASTERDB}" - "${DAEMONUSER}"
 }
 
 # Setup a few catalogs (with dbs) for different conditions
@@ -136,8 +136,8 @@ function teardown {
         su -c "dropdb --if-exists \"${dbn}\"" - "${DAEMONUSER}" >>${LOG} 2>&1
     done
     # delete all registry entries
-    verbose "Deleting all entries from simple_registry table"
-    su -c "psql -A -t -q -c \"delete from ermrest.simple_registry\" \"${MASTERDB}\"" - "${DAEMONUSER}" >>${LOG} 2>&1
+    verbose "Deleting all entries from registry table"
+    su -c "psql -A -t -q -c \"delete from ermrest.registry where id != '0' \" \"${MASTERDB}\"" - "${DAEMONUSER}" >>${LOG} 2>&1
     # cleanup archive directory
     rm -rf "${archive_dir}" >>${LOG} 2>&1
 }

--- a/test/resttest/basics.py
+++ b/test/resttest/basics.py
@@ -222,7 +222,14 @@ class CatalogNaming (common.ErmrestTest):
         delete_id = {my_id}
         try:
             # claim ID as new catalog
-            doc1 = { "id": my_id, "owner": self.my_acl }
+            doc1 = {
+                "id": my_id,
+                "owner": self.my_acl,
+                "name": "resttest test_catalog_post_input %s" % (common.run_ts,),
+                "description": "Secondary test catalog created by a run of the ERMrest rest test suite executed at %s, from the `resttest.basics.CatalogNaming.test_catalog_post_input` test method." % (common.run_ts,),
+                "is_persistent": False,
+                "clone_source": None,
+            }
             r = self.session.post('/ermrest/catalog', json=doc1)
             # check post response
             self.assertHttp(r, 201, 'application/json')
@@ -247,7 +254,14 @@ class CatalogNaming (common.ErmrestTest):
         delete_id = {my_id}
         try:
             # claim ID as unbound alias
-            doc1 = { "id": my_id, "owner": self.my_acl }
+            doc1 = {
+                "id": my_id,
+                "owner": self.my_acl,
+                "name": "resttest test_alias %s" % (common.run_ts,),
+                "description": "Secondary test catalog created by a run of the ERMrest rest test suite executed at %s, from the `resttest.basics.CatalogNaming.test_alias` test method." % (common.run_ts,),
+                "is_persistent": False,
+                "clone_source": None,
+            }
             r = self.session.post('/ermrest/alias', json=doc1)
             # check post response
             self.assertHttp(r, 201, 'application/json')

--- a/test/resttest/basics.py
+++ b/test/resttest/basics.py
@@ -227,7 +227,7 @@ class CatalogNaming (common.ErmrestTest):
                 "owner": self.my_acl,
                 "name": "resttest test_catalog_post_input %s" % (common.run_ts,),
                 "description": "Secondary test catalog created by a run of the ERMrest rest test suite executed at %s, from the `resttest.basics.CatalogNaming.test_catalog_post_input` test method." % (common.run_ts,),
-                "is_persistent": False,
+                #"is_persistent": False,
                 "clone_source": None,
             }
             r = self.session.post('/ermrest/catalog', json=doc1)
@@ -259,7 +259,7 @@ class CatalogNaming (common.ErmrestTest):
                 "owner": self.my_acl,
                 "name": "resttest test_alias %s" % (common.run_ts,),
                 "description": "Secondary test catalog created by a run of the ERMrest rest test suite executed at %s, from the `resttest.basics.CatalogNaming.test_alias` test method." % (common.run_ts,),
-                "is_persistent": False,
+                #"is_persistent": False,
                 "clone_source": None,
             }
             r = self.session.post('/ermrest/alias', json=doc1)

--- a/test/resttest/common.py
+++ b/test/resttest/common.py
@@ -295,7 +295,7 @@ try:
         json={
             "name": "resttest main %s" % (run_ts,),
             "description": "Main test catalog created by a run of the ERMrest rest test suite started at %s" % (run_ts,),
-            "is_persistent": False,
+            #"is_persistent": False,
             "clone_source": None,
         }
     )

--- a/test/resttest/common.py
+++ b/test/resttest/common.py
@@ -6,6 +6,7 @@ import sys
 import platform
 import atexit
 import logging
+import datetime
 
 import requests
 from http import cookiejar
@@ -32,6 +33,7 @@ else:
 # this will be the dynamically generated catalog ID and corresponding path
 cid = None
 cpath = None
+run_ts = datetime.datetime.now(datetime.timezone.utc).astimezone().isoformat('T', 'seconds')
 
 def dump_cookies(cookies, preamble):
     sys.stderr.write(preamble)
@@ -288,7 +290,15 @@ catalog_acls = {
     
 sys.stderr.write('Creating test catalog... ')
 try:
-    _r = primary_session.post('/ermrest/catalog')
+    _r = primary_session.post(
+        '/ermrest/catalog',
+        json={
+            "name": "resttest main %s" % (run_ts,),
+            "description": "Main test catalog created by a run of the ERMrest rest test suite started at %s" % (run_ts,),
+            "is_persistent": False,
+            "clone_source": None,
+        }
+    )
     _r.raise_for_status()
     cid = _r.json()['id']
     cpath = "/ermrest/catalog/%s" % cid


### PR DESCRIPTION
The registry is the built-in `ermrest` database which tracks all API-provisioned ERMrest catalogs. This feature converts the registry into a special catalog accessed at `/ermrest/catalog/0`. This can provide read access to enumerate catalog and alias records as well as limited write access to modify descriptive metadata.

The default configuration provides a self-service policy so that the same client ID who provisioned a catalog may update its metadata. It also has default annotations to provide a basic catalog enumeration UX by visiting `/chaise/recordset/#0/ermrest:registry`.

Because the existing deployment strategy has not defined any overall "owner" ACL for the site operator, the owner ACL of this special catalog is initially empty. The site operator must first change this via local SQL access if they wish to enable API-based management of the registry catalog. For example, run commands like this against the `ermrest` DB:

```
UPDATE _ermrest.known_catalog_acls SET members = ARRAY['group-id-1'] WHERE acl = 'owner';
SELECT _ermrest.model_change_event();
```
There are built-in authorization restrictions so that unsafe changes are not permitted on the registry catalog regardless of how the operator customizes its policy. The existing web APIs must be used to manage the lifecycle of catalogs and aliases and these other APIs will add or remove rows from the registry table.