### PR TITLE
Configure registry descriptor

### DIFF
--- a/ermrest/sql/util.py
+++ b/ermrest/sql/util.py
@@ -17,6 +17,7 @@
 
 import sys
 import pkgutil
+import json
 from ..util import sql_identifier, sql_literal
 from .. import sanepg2, sql
 from ..catalog import Catalog
@@ -94,8 +95,9 @@ def print_redeploy_registry_sql():
     """
     # as it appears in the companion registry.sql
     hardcoded_dsn = """'{"dbname":"ermrest"}'"""
-    # properly SQL quoted from the configured registry
-    configured_dsn = sql_literal(registry.dsn) if registry is not None else hardcoded_dsn
+    # as we will use to connect back to the registry
+    configured_dsn = dict(**catalog_factory._template, **{"dbname":"ermrest"})
+    configured_dsn = sql_literal(json.dumps(configured_dsn))
 
     sys.stdout.write("""
 \\connect template1

--- a/ermrest/sql/util.py
+++ b/ermrest/sql/util.py
@@ -92,6 +92,9 @@ def print_redeploy_registry_sql():
 
        This SQL should be run via 'psql' as postgres or another DB superuser.
     """
+    hardcoded_dsn = '{"dbname":"ermrest"}'
+    configured_dsn = registry.dsn if registry is not None else hardcoded_dsn
+
     sys.stdout.write("""
 \\connect template1
 %(template1_extupgrade)s
@@ -112,7 +115,7 @@ ANALYZE;
 """ % {
     "template1_extupgrade": extupgrade_sql('template1'),
     "ermrest_sql": pkgutil.get_data(sql.__name__, 'ermrest_schema.sql').decode(),
-    "registry_sql": pkgutil.get_data(sql.__name__, 'registry.sql').decode(),
+    "registry_sql": pkgutil.get_data(sql.__name__, 'registry.sql').decode().replace(hardcoded_dsn, configured_dsn),
     "upgrade_sql": pkgutil.get_data(sql.__name__, 'upgrade_registry.sql').decode(),
     "change_owners_sql": pkgutil.get_data(sql.__name__, 'change_owner.sql').decode(),
 })

--- a/ermrest/sql/util.py
+++ b/ermrest/sql/util.py
@@ -17,7 +17,7 @@
 
 import sys
 import pkgutil
-from ..util import sql_identifier
+from ..util import sql_identifier, sql_literal
 from .. import sanepg2, sql
 from ..catalog import Catalog
 from ..apicore import catalog_factory, registry
@@ -92,8 +92,10 @@ def print_redeploy_registry_sql():
 
        This SQL should be run via 'psql' as postgres or another DB superuser.
     """
-    hardcoded_dsn = '{"dbname":"ermrest"}'
-    configured_dsn = registry.dsn if registry is not None else hardcoded_dsn
+    # as it appears in the companion registry.sql
+    hardcoded_dsn = """'{"dbname":"ermrest"}'"""
+    # properly SQL quoted from the configured registry
+    configured_dsn = sql_literal(registry.dsn) if registry is not None else hardcoded_dsn
 
     sys.stdout.write("""
 \\connect template1

--- a/ermrest/sql/util.py
+++ b/ermrest/sql/util.py
@@ -96,7 +96,8 @@ def print_redeploy_registry_sql():
     # as it appears in the companion registry.sql
     hardcoded_dsn = """'{"dbname":"ermrest"}'"""
     # as we will use to connect back to the registry
-    configured_dsn = dict(**catalog_factory._template, **{"dbname":"ermrest"})
+    configured_dsn = dict(catalog_factory._template)
+    configured_dsn.update({"dbname":"ermrest"})
     configured_dsn = sql_literal(json.dumps(configured_dsn))
 
     sys.stdout.write("""


### PR DESCRIPTION
Rather than recording a hard-coded registry catalog descriptor during ermrest-deploy, build one using the catalog factory template in the service configuration file.