### PR TITLE
Relax snaprange discovery authz

### DIFF
--- a/ermrest/url/ast/history.py
+++ b/ermrest/url/ast/history.py
@@ -164,7 +164,7 @@ class CatalogHistory (Api):
              python_status: ( (h_from, h_until), amendver )
              prejson_status: { "snaprange": [ h_from_epoch, h_until_epoch ], "amendver": amendver_epoch }
         """
-        self.enforce_right('owner')
+        self.enforce_right('enumerate')
         h_from, h_until, amendver = _validate_history_snaprange(cur)
         return (
             ( (h_from, h_until), amendver ),

--- a/ermrest/url/ast/history.py
+++ b/ermrest/url/ast/history.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2017-2023 University of Southern California
+# Copyright 2017-2025 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -121,7 +121,6 @@ def _encode_ts(cur, ts):
 
 def _GET(handler, thunk, _post_commit):
     def body(conn, cur):
-        handler.enforce_right('owner')
         handler.set_http_etag(_etag(cur))
         handler.http_check_preconditions()
         return thunk(conn, cur)
@@ -165,6 +164,7 @@ class CatalogHistory (Api):
              python_status: ( (h_from, h_until), amendver )
              prejson_status: { "snaprange": [ h_from_epoch, h_until_epoch ], "amendver": amendver_epoch }
         """
+        self.enforce_right('owner')
         h_from, h_until, amendver = _validate_history_snaprange(cur)
         return (
             ( (h_from, h_until), amendver ),

--- a/test/resttest/history.py
+++ b/test/resttest/history.py
@@ -210,9 +210,9 @@ def _add_history_probes(klass):
         'fkey': lambda m: m['schemas'][_S]['tables'][_T2b]['foreign_keys'][0]['RID'],
     }
 
-    def _add_good_probe(phase, api, ridkey):
+    def _add_good_probe(phase, api, ridkey, http_codes=[200, 403, 401]):
         def _test(self):
-            self._probe_test(api, ridfuncs[ridkey](_model))
+            self._probe_test(api, ridfuncs[ridkey](_model), http_codes=http_codes)
         setattr(klass, 'test_phase%d_probe_%s_%s' % (phase, ridkey, api or 'history'), _test)
 
     def _add_good_amendment(phase, api, ridkey, amendment):
@@ -245,7 +245,7 @@ def _add_history_probes(klass):
         setattr(klass, 'test_phase%d_redactconflict_t%s' % (phase, cridkey), _test)
 
     # phase 0: good probes
-    _add_good_probe(0, None, 'catalog')
+    _add_good_probe(0, None, 'catalog', http_codes=[200, 403, 401])
 
     for ridkey in ['catalog', 'schema', 'table', 'ridcol', 'namecol', 'key', 'fkey']:
         _add_good_probe(0, 'annotation', ridkey)
@@ -308,8 +308,9 @@ class ZHistory (common.ErmrestTest):
                 url += '/%s' % rid
         return url + suffix
 
-    def _probe_test(self, api, rid):
-        self.assertHttp(common.secondary_session.get(self.url(api, rid, None, None)), 403)
+    def _probe_test(self, api, rid, http_codes=[200, 403, 401]):
+        self.assertHttp(common.secondary_session.get(self.url(api, rid, None, None)), http_codes[1])
+        self.assertHttp(common.anonymous_session.get(self.url(api, rid, None, None)), http_codes[2])
         r = self.session.get(self.url(api, rid, None, None))
         self.assertHttp(r, 200, 'application/json')
         h = r.json()

--- a/test/resttest/history.py
+++ b/test/resttest/history.py
@@ -245,7 +245,7 @@ def _add_history_probes(klass):
         setattr(klass, 'test_phase%d_redactconflict_t%s' % (phase, cridkey), _test)
 
     # phase 0: good probes
-    _add_good_probe(0, None, 'catalog', http_codes=[200, 403, 401])
+    _add_good_probe(0, None, 'catalog', http_codes=[200, 200, 200])
 
     for ridkey in ['catalog', 'schema', 'table', 'ridcol', 'namecol', 'key', 'fkey']:
         _add_good_probe(0, 'annotation', ridkey)


### PR DESCRIPTION
Relax authz on GET `/ermrest/catalog/N/history/, ` from requiring "owner" privileges to just require "enumerate" privileges.