### PR TITLE
Detailed change logging

### DIFF
--- a/docs/api-doc/model/rest.md
+++ b/docs/api-doc/model/rest.md
@@ -390,6 +390,101 @@ Typical error response codes include:
 - 403 Forbidden
 - 401 Unauthorized
 
+
+## Table Auditing Configuration
+
+During table creation or alteration, a special annotation `tag:isrd.isi.edu,2026:auditing-configuration` MAY be used to enable optional logging.
+
+The auditing-configuration annotation can be applied at multiple levels of the catalog's model resource hierarchy, but only has an effect when interpreted with respect to a specific table. The purpose of specifying the annotations at other levels are to set common defaults across a whole catalog or schema.
+
+1. Catalog-level annotation to set default for all tables in the catalog;
+2. Schema-level annotation to set default hints for all tables in that schema;
+3. Table-level annotation to configure auditing for that table.
+
+The annotation value can be a document with several fields:
+
+    "annotations": {
+      "tag:isrd.isi.edu,2026:auditing-configuration": {
+        "log_row_writes": true,
+        "insert_show_columns": [column_name, ...],
+        "insert_hide_columns": [column_name, ...],
+        ...
+      }
+    }
+
+When determining the configuration for a given table, the annotations from the model hierarchy are merged on a per-field basis. A given field configuration will be taken from the most specific model level where it is present, i.e. table-level settings are most specific and catalog-level settings are least specific.
+
+The set of supported fields is as follows:
+
+- `log_row_writes`: When `true`, row-level details are logged for write operations.
+- `insert_show_columns`: A list of columns to include in row-level logging of insert operations.
+- `insert_hide_columns`: A list of columns to exclude in row-level logging of insert operations.
+- `update_show_columns`: A list of columns to include in row-level logging of update operations.
+- `update_hide_columns`: A list of columns to exclude in row-level logging of update operations.
+- `delete_show_columns`: A list of columns to include in row-level logging of delete operations.
+- `delete_hide_columns`: A list of columns to exclude in row-level logging of delete operations.
+
+Each list of columns MUST be a list of (string) column names or the value `null` to disable that specific control feature.
+
+### Table Write Logging
+
+When `log_row_writes` is `true`, the service produces additional log messages for each row changed by data insert, update, or delete operations. Because the service API supports bulk operations, a single web request may produce many row-level messages.
+
+The annotation can customize which column values from each row are included in the logged details. Starting with all columns of the table as candidates:
+
+- A candidate is eliminated when a "show" list is configured and the candidate is not named in the explicit list. An absent or `null` "show" list does not eliminate any candidates.
+- A candidate is eliminated when a "hide" list is configured and the candidate is named in the explicit list. An absent or `null` "hide" list does not eliminate any candidates.
+
+A candidate must survive both rounds of elimination to be included in the logged details.
+
+WARNING: the default behavior (described next) will expose catalog data content in the log stream. In a deployment where some tables store sensitive data that should not appear in logs, the operator SHOULD customize the audit configuration to limit which values are logged. There are several potential idioms:
+
+1. Use of the "hide" column lists can suppress specific columns known to be sensitive, while passing other columns through in logs.
+2. Use of the "show" column lists can pass specific columns to the log, while suppressing all other columns. An extreme case may to only show `RID` so that you know which rows were changed and nothing else.
+3. Row-level auditing can be disabled for specific tables.
+
+However, another operating regime may be to keep all data changes in the logs and instead move to protect the log stream where it is captured and archived. This provides the most robust audit trail if there may be a need to investigate the detailed changes made to sensitive content.
+
+
+### Default Table Audit Configuration
+
+The service uses a default configuration, which is conceptually less specific than any catalog-level annotation:
+
+    "annotations": {
+      "tag:isrd.isi.edu,2026:auditing-configuration": {
+        "log_row_writes": true,
+        "insert_hide_columns": ["RMT"],
+        "update_hide_columns": ["RMT"],
+      }
+    }
+
+In other words, the auditing feature is enabled by default for all API-managed schemas. The `RMT` column is suppressed from the message details for insert and update operations, where this value is redundant with the event timestamp encoded in the enclosing row-level audit message. A deployment may set these fields back to `null` in a catalog-level annotation if they would prefer not to hide `RMT` in these scenarios.
+
+A simple idiom to turn off row-level change auditing would be to place a catalog-level annotation:
+
+    "annotations": {
+      "tag:isrd.isi.edu,2026:auditing-configuration": {
+        "log_row_writes": false
+      }
+    }
+
+which overrides the boolean to make the service only emit request-level log messages as it did in prior versions of the software.
+
+### Operational Considerations
+
+The extended audit logging is implemented by means of "trigger" functions in the database. This function is only provisioned or deprovisioned on a table during a limited set of service API operations:
+
+- During individual table _creation_ via `POST` requests to `/catalog/` _cid_ `/schema/` _schema name_ `/table/`
+- During bulk table _creation_ via `POST` requests to `/catalog/` _cid_ `/schema/`
+- During individual table _alteration_ via `PUT` requests to `/catalog/` _cid_ `/schema/` _schema name_ `/table/` _table name_
+
+During these service operations, the trigger is provisioned when `log_row_writes` is `true` and deprovisioned when it is `false`.
+
+During row data writes while the trigger function is provisioned, row-level log events are produced. The function itself consults the annotation state to customize its content.
+
+NOTE: the `log_row_writes` boolean at catalog or schema level influences the default behavior of subsequent table creation in that catalog or schema, respectively. However, changes to this annotation have no effect on the trigger provisioning status of existing tables until they undergo an explit table _alteration_ request.
+
+
 ## Table Deletion
 
 The DELETE method is used to delete a table and all its content:

--- a/ermrest/apicore.py
+++ b/ermrest/apicore.py
@@ -220,6 +220,7 @@ def request_init():
     deriva_ctx.ermrest_catalog_model = None
     deriva_ctx.ermrest_config = global_env
     deriva_ctx.ermrest_catalog_pc = None
+    deriva_ctx.ermrest_catalog_id = None
     deriva_ctx.ermrest_change_notify = amqp_notifier.notify if amqp_notifier else lambda : None
     deriva_ctx.ermrest_model_rights_cache = dict()
 

--- a/ermrest/catalog.py
+++ b/ermrest/catalog.py
@@ -274,7 +274,7 @@ class Catalog (object):
                 msg = str(ev)
                 continue
         raise RuntimeError(msg)
-    
+
     def init_meta(self, conn, cur, owner=None, annotations=None):
         """Initializes the Catalog metadata.
         """
@@ -311,8 +311,7 @@ class Catalog (object):
         model.ermrest_schema.set_annotations(
             conn, cur,
             {
-                "tag:isrd.isi.edu,2026:auditing-configuration": {
-                    "log_row_writes": True,
+                Table.tag_auditing_configuration: {
                     "insert_hide_columns": ["RMT", "annotation_value"],
                     "update_hide_columns": ["RMT", "annotation_value"],
                     "delete_hide_columns": ["annotation_value"],
@@ -324,4 +323,4 @@ class Catalog (object):
             # only enable audit triggers for the reified catalog model
             # (not other special metadata tables)
             if table.name.startswith('known_'):
-                cur.execute(table.enable_audit_triggers_sql())
+                cur.execute(table.manage_audit_triggers_sql())

--- a/ermrest/catalog.py
+++ b/ermrest/catalog.py
@@ -301,30 +301,27 @@ class Catalog (object):
 
         model = self.get_model(cur, self._config)
 
-        ## enable model and ACL auditing
-        for tname in [
-                "known_schemas",
-                "known_tables",
-                "known_columns",
-                "known_keys",
-                "known_fkeys",
-                "known_pseudo_fkeys",
-                #
-                "known_catalog_acls",
-                "known_table_acls",
-                "known_column_acls",
-                "known_fkey_acls",
-                "known_pseudo_fkey_acls",
-                #
-                "known_table_dynacls",
-                "known_column_dynacls",
-                "known_fkey_dynacls",
-                "known_pseudo_fkey_dynacls",
-        ]:
-            table = model.ermrest_schema.tables[tname]
-            cur.execute(table.enable_audit_triggers_sql())
-
         ## initial policy
         model.acls['owner'] = owner # set so enforcement won't deny subsequent set_acl()
         model.set_acl(cur, 'owner', owner)
         model.set_annotations(conn, cur, annotations_merged)
+
+        ## enable model/config auditing
+        #  but simplify annotation logging to only log keys and not (possibly large) values
+        model.ermrest_schema.set_annotations(
+            conn, cur,
+            {
+                "tag:isrd.isi.edu,2026:auditing-configuration": {
+                    "log_row_writes": True,
+                    "insert_hide_columns": ["RMT", "annotation_value"],
+                    "update_hide_columns": ["RMT", "annotation_value"],
+                    "delete_hide_columns": ["annotation_value"],
+                }
+            }
+        )
+
+        for table in model.ermrest_schema.tables.values():
+            # only enable audit triggers for the reified catalog model
+            # (not other special metadata tables)
+            if table.name.startswith('known_'):
+                cur.execute(table.enable_audit_triggers_sql())

--- a/ermrest/catalog.py
+++ b/ermrest/catalog.py
@@ -299,8 +299,32 @@ class Catalog (object):
         if annotations:
             annotations_merged.update(annotations)
 
-        ## initial policy
         model = self.get_model(cur, self._config)
+
+        ## enable model and ACL auditing
+        for tname in [
+                "known_schemas",
+                "known_tables",
+                "known_columns",
+                "known_keys",
+                "known_fkeys",
+                "known_pseudo_fkeys",
+                #
+                "known_catalog_acls",
+                "known_table_acls",
+                "known_column_acls",
+                "known_fkey_acls",
+                "known_pseudo_fkey_acls",
+                #
+                "known_table_dynacls",
+                "known_column_dynacls",
+                "known_fkey_dynacls",
+                "known_pseudo_fkey_dynacls",
+        ]:
+            table = model.ermrest_schema.tables[tname]
+            cur.execute(table.enable_audit_triggers_sql())
+
+        ## initial policy
         model.acls['owner'] = owner # set so enforcement won't deny subsequent set_acl()
         model.set_acl(cur, 'owner', owner)
         model.set_annotations(conn, cur, annotations_merged)

--- a/ermrest/model/table.py
+++ b/ermrest/model/table.py
@@ -320,6 +320,8 @@ SELECT _ermrest.record_new_table(%(schema_rid)s, %(tnamestr)s);
         )
         table.rid = cur.fetchone()[0]
 
+        cur.execute(table.enable_audit_triggers_sql())
+
         if not table.has_right('owner'):
             # client gets ownership by default
             table.acls['owner'] = [deriva_ctx.webauthn2_context.get_client_id()]
@@ -671,12 +673,6 @@ CREATE OR REPLACE TRIGGER ermrest_audit_delete
         """Return idempotent table auditing trigger definitions as SQL string."""
         if not self.rid:
             raise ValueError('Cannot use table auditing on table %r.%r which lacks a table RID' % (
-                table.schema.name,
-                table.name,
-            ))
-
-        if 'RID' not in self.columns:
-            raise ValueError('Cannot use table auditing on table %r.%r which lacks a RID column' % (
                 table.schema.name,
                 table.name,
             ))

--- a/ermrest/model/table.py
+++ b/ermrest/model/table.py
@@ -643,3 +643,58 @@ WHERE "RID" = %s;
     def freetext_column(self):
         return FreetextColumn(self)
 
+    @classmethod
+    def _create_audit_triggers_sql(cls, trid, sname, tname):
+        template = """
+CREATE OR REPLACE TRIGGER ermrest_audit_insert
+  AFTER INSERT ON %(sname_ident)s.%(tname_ident)s
+  REFERENCING NEW TABLE AS ermrest_audit_newtuples
+  FOR EACH STATEMENT EXECUTE PROCEDURE _ermrest.table_audit(%(trid_literal)s);
+
+CREATE OR REPLACE TRIGGER ermrest_audit_update
+  AFTER UPDATE ON %(sname_ident)s.%(tname_ident)s
+  REFERENCING OLD TABLE AS ermrest_audit_oldtuples NEW TABLE AS ermrest_audit_newtuples
+  FOR EACH STATEMENT EXECUTE PROCEDURE _ermrest.table_audit(%(trid_literal)s);
+
+CREATE OR REPLACE TRIGGER ermrest_audit_delete
+  AFTER DELETE ON %(sname_ident)s.%(tname_ident)s
+  REFERENCING OLD TABLE AS ermrest_audit_oldtuples
+  FOR EACH STATEMENT EXECUTE PROCEDURE _ermrest.table_audit(%(trid_literal)s);
+"""
+        return template % {
+            "trid_literal": sql_literal(trid),
+            "sname_ident": sql_identifier(sname),
+            "tname_ident": sql_identifier(tname),
+        }
+
+    def enable_audit_triggers_sql(self) -> str:
+        """Return idempotent table auditing trigger definitions as SQL string."""
+        if not self.rid:
+            raise ValueError('Cannot use table auditing on table %r.%r which lacks a table RID' % (
+                table.schema.name,
+                table.name,
+            ))
+
+        if 'RID' not in self.columns:
+            raise ValueError('Cannot use table auditing on table %r.%r which lacks a RID column' % (
+                table.schema.name,
+                table.name,
+            ))
+
+        return self._create_audit_triggers_sql(self.rid, self.schema.name, self.name)
+
+    @classmethod
+    def _drop_audit_triggers_sql(cls, sname, tname):
+        template = """
+DROP TRIGGER IF EXISTS ermrest_audit_insert ON %(sname_ident)s.%(tname_ident)s;
+DROP TRIGGER IF EXISTS ermrest_audit_update ON %(sname_ident)s.%(tname_ident)s;
+DROP TRIGGER IF EXISTS ermrest_audit_delete ON %(sname_ident)s.%(tname_ident)s;
+"""
+        return template % {
+            "sname_ident": sql_identifier(sname),
+            "tname_ident": sql_identifier(tname),
+        }
+
+    def disable_audit_triggers_sql(self) -> str:
+        """Return idempotent table auditing trigger deletions as SQL string."""
+        return self._drop_audit_triggers_sql(self.schema.name, self.name)

--- a/ermrest/model/table.py
+++ b/ermrest/model/table.py
@@ -67,6 +67,7 @@ class Table (object):
     """
     tag_indexing_preferences = 'tag:isrd.isi.edu,2018:indexing-preferences'
     tag_history_capture = 'tag:isrd.isi.edu,2020:history-capture'
+    tag_auditing_configuration = 'tag:isrd.isi.edu,2026:auditing-configuration'
     
     def __init__(self, schema, name, columns, kind, comment=None, annotations={}, acls={}, dynacls={}, rid=None):
         self.schema = schema
@@ -320,8 +321,6 @@ SELECT _ermrest.record_new_table(%(schema_rid)s, %(tnamestr)s);
         )
         table.rid = cur.fetchone()[0]
 
-        cur.execute(table.enable_audit_triggers_sql())
-
         if not table.has_right('owner'):
             # client gets ownership by default
             table.acls['owner'] = [deriva_ctx.webauthn2_context.get_client_id()]
@@ -332,6 +331,8 @@ SELECT _ermrest.record_new_table(%(schema_rid)s, %(tnamestr)s);
         table.set_annotations(conn, cur, annotations)
         table.set_acls(cur, acls)
         table.set_dynacls(cur, dynacls)
+
+        cur.execute(table.manage_audit_triggers_sql())
 
         cur.execute("""
 SELECT
@@ -694,3 +695,14 @@ DROP TRIGGER IF EXISTS ermrest_audit_delete ON %(sname_ident)s.%(tname_ident)s;
     def disable_audit_triggers_sql(self) -> str:
         """Return idempotent table auditing trigger deletions as SQL string."""
         return self._drop_audit_triggers_sql(self.schema.name, self.name)
+
+    def manage_audit_triggers_sql(self) -> str:
+        """Return idempotent table auditing trigger manipulation as SQL string."""
+        cfg = {}
+        cfg.update(self.schema.model.annotations.get(self.tag_auditing_configuration, {}))
+        cfg.update(self.schema.annotations.get(self.tag_auditing_configuration, {}))
+        cfg.update(self.annotations.get(self.tag_auditing_configuration, {}))
+        if cfg.get('log_row_writes', True):
+            return self.enable_audit_triggers_sql()
+        else:
+            return self.disable_audit_triggers_sql()

--- a/ermrest/sanepg2.py
+++ b/ermrest/sanepg2.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2023 University of Southern California
+# Copyright 2013-2026 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -60,10 +60,7 @@ CREATE TEMPORARY TABLE IF NOT EXISTS ermrest_audit_log (
     id serial PRIMARY KEY,
     ts timestamptz NOT NULL,
     table_rid text NOT NULL,
-    schema_name text NOT NULL,
-    table_name text NOT NULL,
     op text NOT NULL,
-    row_rid text NOT NULL,
     detail jsonb
 )
 ON COMMIT DELETE ROWS;
@@ -169,9 +166,22 @@ class PooledConnection (object):
         try:
             result = bodyfunc(self.conn, self.cur)
             cur = self.conn.cursor()
-            cur.execute("SELECT * FROM ermrest_audit_log")
-            for ser, ts, trid, sname, tname, op, row_rid, detail in cur:
+            cur.execute("""
+SELECT
+  l.id,
+  l.ts::text,
+  l.table_rid,
+  s.schema_name,
+  t.table_name,
+  l.op,
+  l.detail
+FROM ermrest_audit_log l
+JOIN _ermrest.known_tables t ON (l.table_rid = t."RID")
+JOIN _ermrest.known_schemas s ON (t.schema_rid = s."RID")
+""")
+            for ser, ts, trid, sname, tname, op, detail in cur:
                 deriva_ctx.ermrest_request_trace({
+                    "audit_ts": ts,
                     "audit_op": op,
                     "catalog": deriva_ctx.ermrest_catalog_id,
                     "table": [trid, sname, tname],

--- a/ermrest/sanepg2.py
+++ b/ermrest/sanepg2.py
@@ -45,7 +45,7 @@ import sys
 import traceback
 import datetime
 import math
-from webauthn2.util import deriva_debug
+from webauthn2.util import deriva_debug, deriva_ctx
 
 class connection (psycopg2.extensions.connection):
     """Customized psycopg2 connection factory with per-execution() cursor support.
@@ -54,6 +54,22 @@ class connection (psycopg2.extensions.connection):
     def __init__(self, dsn):
         psycopg2.extensions.connection.__init__(self, dsn)
         self._curnumber  = 1
+        cur = self.cursor()
+        cur.execute("""
+CREATE TEMPORARY TABLE IF NOT EXISTS ermrest_audit_log (
+    id serial PRIMARY KEY,
+    ts timestamptz NOT NULL,
+    table_rid text NOT NULL,
+    schema_name text NOT NULL,
+    table_name text NOT NULL,
+    op text NOT NULL,
+    row_rid text NOT NULL,
+    detail jsonb
+)
+ON COMMIT DELETE ROWS;
+""")
+        self.commit()
+        del cur
 
     def execute(self, stmt, vars=None):
         """Name and create a server-side cursor with withhold=True and run statement in it.
@@ -152,6 +168,16 @@ class PooledConnection (object):
         assert self.conn is not None
         try:
             result = bodyfunc(self.conn, self.cur)
+            cur = self.conn.cursor()
+            cur.execute("SELECT * FROM ermrest_audit_log")
+            for ser, ts, trid, sname, tname, op, row_rid, detail in cur:
+                deriva_ctx.ermrest_request_trace({
+                    "audit_op": op,
+                    "catalog": deriva_ctx.ermrest_catalog_id,
+                    "table": [trid, sname, tname],
+                    "detail": detail,
+                })
+            del cur
             self.conn.commit()
             return finalfunc(result)
         except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:

--- a/ermrest/sanepg2.py
+++ b/ermrest/sanepg2.py
@@ -153,7 +153,7 @@ class PooledConnection (object):
             self.conn = self.used_pool.getconn()
         else:
             self.used_pool = None
-            self.conn = psycopg2.extensions.connection(dsn)
+            self.conn = connection(dsn)
         self.conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_SERIALIZABLE)
         self.cur = self.conn.cursor()
 

--- a/ermrest/sql/ermrest_schema.sql
+++ b/ermrest/sql/ermrest_schema.sql
@@ -1,6 +1,6 @@
 
 -- 
--- Copyright 2012-2024 University of Southern California
+-- Copyright 2012-2026 University of Southern California
 -- 
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -316,6 +316,86 @@ BEGIN
     IF oldj ? 'RMT' THEN NEW."RMT" := now(); END IF;
   END IF;
   RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- use as an AFTER trigger
+CREATE OR REPLACE FUNCTION _ermrest.table_audit() RETURNS TRIGGER AS $$
+DECLARE
+  trid text;
+  sname text;
+  tname text;
+BEGIN
+
+  trid := TG_ARGV[0];
+
+  CREATE TEMPORARY TABLE IF NOT EXISTS ermrest_audit_log (
+    id serial PRIMARY KEY,
+    ts timestamptz NOT NULL,
+    table_rid text NOT NULL,
+    schema_name text NOT NULL,
+    table_name text NOT NULL,
+    op text NOT NULL,
+    row_rid text NOT NULL,
+    detail jsonb
+  ) ON COMMIT DELETE ROWS;
+
+  SELECT s.schema_name, t.table_name
+  INTO sname, tname
+  FROM _ermrest.known_tables t
+  JOIN _ermrest.known_schemas s ON (t.schema_rid = s."RID")
+  WHERE t."RID" = trid;
+
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO ermrest_audit_log (ts, table_rid, schema_name, table_name, op, row_rid, detail)
+    SELECT
+      now(),
+      trid,
+      sname,
+      tname,
+      'insert',
+      n."RID",
+      (SELECT
+         jsonb_object_agg(nj.k, nj.v)
+       FROM jsonb_each(to_jsonb(n)) nj (k, v)
+      )
+    FROM ermrest_audit_newtuples n;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    INSERT INTO ermrest_audit_log (ts, table_rid, schema_name, table_name, op, row_rid, detail)
+    SELECT
+      now(),
+      trid,
+      sname,
+      tname,
+      'modify',
+      n."RID",
+      (SELECT
+         jsonb_object_agg(nj.k, nj.v)
+       FROM jsonb_each(to_jsonb(n)) nj (k, v)
+      )
+    FROM ermrest_audit_newtuples n;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    INSERT INTO ermrest_audit_log (ts, table_rid, schema_name, table_name, op, row_rid, detail)
+    SELECT
+      now(),
+      trid,
+      sname,
+      tname,
+      'delete',
+      o."RID",
+      (SELECT
+         jsonb_object_agg(oj.k, oj.v)
+       FROM jsonb_each(to_jsonb(o)) oj (k, v)
+      )
+    FROM ermrest_audit_oldtuples o;
+  END IF;
+
+  RETURN NULL;
+
 END;
 $$ LANGUAGE plpgsql;
 

--- a/ermrest/sql/ermrest_schema.sql
+++ b/ermrest/sql/ermrest_schema.sql
@@ -323,73 +323,105 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION _ermrest.table_audit() RETURNS TRIGGER AS $$
 DECLARE
   trid text;
-  sname text;
-  tname text;
+  cfg jsonb;
+  ckey text;
+  showcols text[];
+  hidecols text[];
 BEGIN
 
   trid := TG_ARGV[0];
+
+  SELECT
+    '{"log_row_writes": true, "insert_hide_columns": ["RMT"], "update_hide_columns": ["RMT"]}'::jsonb || COALESCE(
+      (SELECT annotation_value
+       FROM _ermrest.known_catalog_annotations
+       WHERE annotation_uri = 'tag:isrd.isi.edu,2026:auditing-configuration'),
+      '{}'::jsonb
+    ) || COALESCE(
+      (SELECT s.annotation_value
+       FROM _ermrest.known_schema_annotations s
+       JOIN _ermrest.known_tables t ON (s.schema_rid = t.schema_rid)
+       WHERE annotation_uri = 'tag:isrd.isi.edu,2026:auditing-configuration'
+         AND t."RID" = trid),
+      '{}'::jsonb
+    ) || COALESCE(
+      (SELECT annotation_value
+       FROM _ermrest.known_table_annotations t
+       WHERE annotation_uri = 'tag:isrd.isi.edu,2026:auditing-configuration'
+         AND t."RID" = trid),
+      '{}'::jsonb
+    ) INTO cfg;
+
+  IF cfg->'log_row_writes' = 'false'::jsonb THEN
+    -- early return if trigger is provisioned but extra logging was disabled??
+    RETURN NULL;
+  END IF;
 
   CREATE TEMPORARY TABLE IF NOT EXISTS ermrest_audit_log (
     id serial PRIMARY KEY,
     ts timestamptz NOT NULL,
     table_rid text NOT NULL,
-    schema_name text NOT NULL,
-    table_name text NOT NULL,
     op text NOT NULL,
-    row_rid text NOT NULL,
     detail jsonb
   ) ON COMMIT DELETE ROWS;
 
-  SELECT s.schema_name, t.table_name
-  INTO sname, tname
-  FROM _ermrest.known_tables t
-  JOIN _ermrest.known_schemas s ON (t.schema_rid = s."RID")
-  WHERE t."RID" = trid;
+  ckey := LOWER(TG_OP) || '_show_columns';
+  SELECT
+    CASE
+      WHEN jsonb_typeof(cfg->ckey) = 'array' THEN (SELECT array_agg(v) FROM jsonb_array_elements_text(cfg->ckey) a(v))
+      ELSE NULL::text[]
+    END
+  INTO showcols;
+
+  ckey := LOWER(TG_OP) || '_hide_columns';
+  SELECT
+    CASE
+      WHEN jsonb_typeof(cfg->ckey) = 'array' THEN (SELECT array_agg(v) FROM jsonb_array_elements_text(cfg->ckey) a(v))
+      ELSE NULL::text[]
+    END
+  INTO hidecols;
 
   IF TG_OP = 'INSERT' THEN
-    INSERT INTO ermrest_audit_log (ts, table_rid, schema_name, table_name, op, row_rid, detail)
+    INSERT INTO ermrest_audit_log (ts, table_rid, op, detail)
     SELECT
       now(),
       trid,
-      sname,
-      tname,
       'insert',
-      n."RID",
       (SELECT
          jsonb_object_agg(nj.k, nj.v)
        FROM jsonb_each(to_jsonb(n)) nj (k, v)
+       WHERE (showcols IS NULL OR nj.k = ANY (showcols))
+         AND (hidecols IS NULL OR NOT nj.k = ANY (hidecols))
       )
     FROM ermrest_audit_newtuples n;
   END IF;
 
   IF TG_OP = 'UPDATE' THEN
-    INSERT INTO ermrest_audit_log (ts, table_rid, schema_name, table_name, op, row_rid, detail)
+    INSERT INTO ermrest_audit_log (ts, table_rid, op, detail)
     SELECT
       now(),
       trid,
-      sname,
-      tname,
-      'modify',
-      n."RID",
+      'update',
       (SELECT
          jsonb_object_agg(nj.k, nj.v)
        FROM jsonb_each(to_jsonb(n)) nj (k, v)
+       WHERE (showcols IS NULL OR nj.k = ANY (showcols))
+         AND (hidecols IS NULL OR NOT nj.k = ANY (hidecols))
       )
     FROM ermrest_audit_newtuples n;
   END IF;
 
   IF TG_OP = 'DELETE' THEN
-    INSERT INTO ermrest_audit_log (ts, table_rid, schema_name, table_name, op, row_rid, detail)
+    INSERT INTO ermrest_audit_log (ts, table_rid, op, detail)
     SELECT
       now(),
       trid,
-      sname,
-      tname,
       'delete',
-      o."RID",
       (SELECT
          jsonb_object_agg(oj.k, oj.v)
        FROM jsonb_each(to_jsonb(o)) oj (k, v)
+       WHERE (showcols IS NULL OR oj.k = ANY (showcols))
+         AND (hidecols IS NULL OR NOT oj.k = ANY (hidecols))
       )
     FROM ermrest_audit_oldtuples o;
   END IF;

--- a/ermrest/sql/ermrest_schema.sql
+++ b/ermrest/sql/ermrest_schema.sql
@@ -332,7 +332,7 @@ BEGIN
   trid := TG_ARGV[0];
 
   SELECT
-    '{"log_row_writes": true, "insert_hide_columns": ["RMT"], "update_hide_columns": ["RMT"]}'::jsonb || COALESCE(
+    '{"insert_hide_columns": ["RMT"], "update_hide_columns": ["RMT"]}'::jsonb || COALESCE(
       (SELECT annotation_value
        FROM _ermrest.known_catalog_annotations
        WHERE annotation_uri = 'tag:isrd.isi.edu,2026:auditing-configuration'),

--- a/ermrest/sql/util.py
+++ b/ermrest/sql/util.py
@@ -1,6 +1,6 @@
 
 #
-# Copyright 2017-2024 University of Southern California
+# Copyright 2017-2026 University of Southern California
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ermrest/url/ast/catalog.py
+++ b/ermrest/url/ast/catalog.py
@@ -230,6 +230,7 @@ class Catalog (Api):
         
         assert deriva_ctx.ermrest_catalog_pc is None
         deriva_ctx.ermrest_catalog_pc = sanepg2.PooledConnection(self.manager.dsn)
+        deriva_ctx.ermrest_catalog_id = catalog_id
 
         Api.__init__(self, self)
         # now enforce read permission

--- a/ermrest/url/ast/model.py
+++ b/ermrest/url/ast/model.py
@@ -279,7 +279,10 @@ class Schema (Api):
         try:
             # handle alteration of existing schema
             schema = deriva_ctx.ermrest_catalog_model.schemas.get_enumerable(self.name)
-            return schema.update(conn, cur, schemadoc, deriva_ctx.ermrest_config)
+            res = schema.update(conn, cur, schemadoc, deriva_ctx.ermrest_config)
+            for table in schema.tables.values():
+                cur.execute(table.manage_audit_triggers_sql())
+            return res
         except exception.ConflictModel as e:
             # handle creation of new schema, same as POST /schema/
             schemas = Schemas(self.catalog)
@@ -593,13 +596,18 @@ class Annotations (Api):
     def GET(self, uri):
         return _GET(self, self.GET_body, _post_commit_json)
 
+    def _after_modify_body(self, conn, cur):
+        pass
+
     def PUT_body(self, conn, cur, value):
         subject = self.GET_subject(conn, cur)
         if self.key is None:
             subject.set_annotations(conn, cur, value)
+            self._after_modify_body(conn, cur)
             return False
         else:
             oldval = subject.set_annotation(conn, cur, self.key, value)
+            self._after_modify_body(conn, cur)
             return oldval is None
 
     def PUT(self, uri):
@@ -616,6 +624,7 @@ class Annotations (Api):
         if self.key not in subject.annotations:
             raise exception.rest.NotFound('annotation "%s" on "%s"' % (self.key, subject))
         subject.delete_annotation(conn, cur, self.key)
+        self._after_modify_body(conn, cur)
         return ''
 
     def DELETE(self, uri):
@@ -625,13 +634,31 @@ class CatalogAnnotations(Annotations):
     def __init__(self, catalog):
         Annotations.__init__(self, catalog, catalog)
 
+    def _after_modify_body(self, conn, cur):
+        catalog = self.GET_subject(conn, cur)
+        for schema in catalog.schemas.values():
+            for table in schema.tables.values():
+                cur.execute(table.manage_audit_triggers_sql())
+        for table in catalog.ermrest_schema.tables.values():
+            if table.name.startswith('known_'):
+                cur.execute(table.manage_audit_triggers_sql())
+
 class TableAnnotations (Annotations):
     def __init__(self, table):
         Annotations.__init__(self, table.schema.catalog, table)
 
+    def _after_modify_body(self, conn, cur):
+        table = self.GET_subject(conn, cur)
+        cur.execute(table.manage_audit_triggers_sql())
+
 class SchemaAnnotations (Annotations):
     def __init__(self, schema):
         Annotations.__init__(self, schema.catalog, schema)
+
+    def _after_modify_body(self, conn, cur):
+        schema = self.GET_subject(conn, cur)
+        for table in schema.tables.values():
+            cur.execute(table.manage_audit_triggers_sql())
 
 class ColumnAnnotations (Annotations):
     def __init__(self, column):
@@ -730,7 +757,9 @@ class Table (Api):
         try:
             # handle alteration of existing table
             table = schema.tables.get_enumerable(self.name.one_str())
-            return table.update(conn, cur, tabledoc, deriva_ctx.ermrest_config)
+            res = table.update(conn, cur, tabledoc, deriva_ctx.ermrest_config)
+            cur.execute(table.manage_audit_triggers_sql())
+            return res
         except exception.ConflictModel as e:
             # handle creation of new table, same as POST /table/
             tables = Tables(self.schema)


### PR DESCRIPTION
Adds detailed record change logging for audit purposes.

The mechanism is a new temporary audit table and triggers which capture row changes and aggregate them into the audit table. The web service retrieves these audit records and emits them to the logging facility as part of the normal mutation request dispatch process.

An annotation is used to configure the audit logging. This includes enabling or disabling the extended audit capture for a given table as well as customizing which columns will be included in the log.