### PR TITLE
Add support for JSON encoding of array columns in CSV representation

### DIFF
--- a/docs/api-doc/data/naming.md
+++ b/docs/api-doc/data/naming.md
@@ -526,6 +526,17 @@ If the set denoted by the resource name (without the limit modifier) has _k_ ele
 
 The `limit` query parameter is only meaningful on retrieval requests using the `GET` method described in [Data Operations](#data-operations).
 
+## Arrays Query Parameter
+
+An optional `arrays` query parameter can select an alternate encoding for array typed columns in `text/csv` query results:
+
+- _service_ `/catalog/` _cid_ [ `@` _revision_ ] `/entity/` _path_ ` ... ?arrays=` _encoding_
+- _service_ `/catalog/` _cid_ [ `@` _revision_ ] `/attribute/` _path_ `/` _projection_ `,` ... `?arrays=` _encoding_
+- _service_ `/catalog/` _cid_ [ `@` _revision_ ] `/attributegroup/` _path_ `/` _group key_ `,` ... `;` _projection_ `,` ... `?arrays=` _encoding_
+- _service_ `/catalog/` _cid_ [ `@` _revision_ ] `/agreggate/` _path_ `/` _group key_ `,` ... `;` _projection_ `,` ... `?arrays=` _encoding_
+
+At time of writing, the only alternate _encoding_ is `json` to select JSON array syntax. The backwards-compatible default encoding, in the absence of this parameter is the PostgreSQL array syntax.
+
 ## Data Paging
 
 The [sort modifier](#sort-modifier), [limit parameter](#limit-query-parameter), and [paging modifiers](#paging-modifiers) can be combined to express paged access to set-based data resources:

--- a/docs/api-doc/index.md
+++ b/docs/api-doc/index.md
@@ -195,6 +195,7 @@ The [data resources](data/naming.md) make use of a model-driven language for den
 1. [Nondefaults Query Parameter](data/naming.md#nondefaults-query-parameter)
 1. [Onconflict Query Parameter](data/naming.md#onconflict-query-parameter)
 1. [Limit Query Parameter](data/naming.md#limit-query-parameter)
+1. [Arrays Query Parameter](data/naming.md#arrays-query-parameter)
 
 The sort, paging, and limit syntax together can support [paged data access](data/naming.md#data-paging).
 
@@ -382,10 +383,12 @@ scalar types except the regular-expression matches which only apply to
 ##### Arrays of Scalars
 
 ERMrest supports columns storing arrays of the preceding scalar
-types. These arrays are encoded differently depending on the MIME type:
+types. In requests and responses, these arrays are encoded differently
+depending on the MIME type:
 
 - As native JSON array content in JSON input/output formats, e.g. `{"array_column_name": ["value1", "value2"], "scalar_column_name": "value3"}`
-- As PostgreSQL-formatted arrays in CSV input/output formats, e.g. `"{value1,value2,value3}",value3`
+- As PostgreSQL-formatted arrays in CSV input/output formats, e.g. `"{value1,value2}",value3`.
+- Optionally, JSON array content is also supported in CSV input/output formats, but then must obey CSV quoting and escaping rules. The example row  `"[""value1"",""value2""]",value3` contains two columns, with the first bearing the JSON value `["value1","value2"]`.
 
 The [binary filter predicate](data/naming.md#binary-filter-predicate)
 language of ERMrest URIs compare each scalar element in a stored array
@@ -396,6 +399,18 @@ considered to match if *any* contained array element individually
 matches using the scalar comparison.
 
 A column storing an array of scalars MAY be used as a unique key or foreign key, subject to PostgreSQL native interpretation of array equality. However, it is RECOMMENDED that data modelers consider normalizing their schema to avoid such constructs.
+
+##### Computed JSON Columns
+
+A number of ERMrest special output forms produce composite values
+which are effectively computed `jsonb` columns:
+
+- `array` and `array_d` aggregates are JSON arrays
+- `bin` binning results are JSON arrays
+- `trs` and `tcrs` rights-summaries are JSON objects
+
+Unlike stored array columns, these output values are computed _after_
+filtering and are never involved in filter predicates.
 
 ##### Experimental Types
 
@@ -409,7 +424,7 @@ for other reasons:
 - `numeric`: Arbitrary-precision decimal numerical data.
 - `time` and `timetz`: Time values lacking date information.
 - `timestamp`: Timestamps lacking timezone information.
-- `json`: JSON text strings.
+- `json`: JSON text strings. We recommend the `jsonb` type instead.
 - various `text` and `character` types with length constraints: No
   length constraints or padding are considered or enforced by ERMrest
   and for the most part these map to variable-length `text` storage
@@ -426,6 +441,14 @@ as described in [RFC 4180](https://tools.ietf.org/html/rfc4180). If
 deviation between the RFC and ERMrest are found, please report them as
 a bug in the ERMrest issue tracker.
 
+Note, ERMrest deviates from RFC 4180 and accepts a Unix-style
+_linefeed_ character as record terminator as well as the two-byte
+sequence _carriage return_ + _linefeed_. This usage should be
+consistent through an entire CSV input, not mixed on a per record
+basis. ERMrest may also produce CSV with Unix-style record terminators,
+depending on the configuration and behavior of the PostgreSQL server
+being used for the ERMrest deployment.
+
 Refer to the RFC for full CSV format details, but here are a few
 points worth noting:
 
@@ -441,10 +464,15 @@ points worth noting:
 
 ##### NULL values
 
-As a further note, ERMrest interprets quoted and unquoted empty fields distinctly:
+As a further note, ERMrest interprets quoted and unquoted empty fields
+distinctly:
 
 - `...,,...`: NULL value
 - `...,"",...`: empty string
+
+However, these two scenarios will be conflated by typical CSV decoders
+which interpret both as the empty string and have no concept of NULL
+values.
 
 ##### Example CSV Content
 

--- a/docs/api-doc/rest-catalog.md
+++ b/docs/api-doc/rest-catalog.md
@@ -48,6 +48,7 @@ Known feature flags at time of writing of this document:
 - `quantified_rid_lists`: Service supports `RID=all(...)` and `RID=any(...)`, a bug-fix to the `quantified_value_lists` feature.
 - `rid_lease`: Service supports `?nondefaults=RID` for POST operations on the `/entity/` API by clients who are not catalog owners. Such use is limited to the rules described for [Entity Creation with Defaults](data/rest.md#entity-creation-with-defaults).
 - `registry_catalog`: Service supports special catalog `0` to introspect the registry, and also supports additional metadata parameters when creating catalogs and creating or updating aliases.
+- `csv_array_json`: Service recognizes JSON or PostgreSQL syntax for array typed columns in `text/csv` tabular input, and supports JSON syntax for array retrieval in `text/csv` tabular output when the `arrays=json` query parameter is added to the URL.
 
 Generally, absence of a feature flag means the service is running
 older software which predates the release of the feature. A flag will

--- a/ermrest/ermpath/resource.py
+++ b/ermrest/ermpath/resource.py
@@ -338,13 +338,20 @@ def sort_components(sortvec, is_before):
 system_colnames = {'RID','RCT','RMT','RCB','RMB'}
 
 def _create_temp_input_tables(cur, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, in_content_type, drop_tables=None, use_defaults=None):
+    """Return dict of variable set of temporary table names
+
+    {"data": ..., "csv": ..., "json": ...,}
+    """
     if use_defaults is None:
         use_defaults = set()
-    input_table = random_name("input_data_")
-    input_json_table = None
+
+    tnames = {
+        "data": random_name("input_data_"),
+    }
+
     cur.execute(
         "CREATE TEMPORARY TABLE %s (%s)" % (
-            sql_identifier(input_table),
+            sql_identifier(tnames["data"]),
             ','.join(
                 [
                     c.input_ddl(mkcol_aliases.get(c), c not in use_defaults)
@@ -356,14 +363,39 @@ def _create_temp_input_tables(cur, mkcols, nmkcols, mkcol_aliases, nmkcol_aliase
             )
         )
     )
-    if drop_tables is not None:
-        drop_tables.append(input_table)
+
+    if in_content_type in [ 'text/csv' ]:
+        def input_ddl(c, aliases, enforce_notnull):
+            # we will load CSV array cols as text and decode later...
+            cname = aliases.get(c, c.name)
+            ctype = 'text' if c.type.is_array else c.type.sql(basic_storage=True)
+            notnull = "NOT NULL" if c.nullok is False and enforce_notnull else ""
+            return "%s %s %s" % (sql_identifier(cname), ctype, notnull)
+
+        tnames["csv"] = random_name("input_csv_")
+        cur.execute(
+            "CREATE TEMPORARY TABLE %s (%s)" % (
+                sql_identifier(tnames["csv"]),
+                ','.join(
+                    [
+                        input_ddl(c, mkcol_aliases, c not in use_defaults)
+                        for c in mkcols
+                    ] + [
+                        input_ddl(c, nmkcol_aliases, c not in use_defaults)
+                        for c in nmkcols
+                    ]
+                )
+            )
+        )
+
     if in_content_type in [ 'application/x-json-stream' ]:
-        input_json_table = random_name("input_json_")
-        cur.execute( "CREATE TEMPORARY TABLE %s (j json)" % sql_identifier(input_json_table))
-        if drop_tables is not None:
-            drop_tables.append(input_json_table)
-    return input_table, input_json_table
+        tnames["json"] = random_name("input_json_")
+        cur.execute( "CREATE TEMPORARY TABLE %s (j json)" % sql_identifier(tnames["json"]))
+
+    if drop_tables is not None:
+        drop_tables.extend(tnames.values())
+
+    return tnames
 
 def _build_json_projections(mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults=None):
     """Build up intermediate SQL representations of each JSON record as field lists."""
@@ -417,22 +449,25 @@ def _build_json_projections(mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_
     # split back into json_cols, json_projection lists
     return zip(*parts)
 
-def _load_input_data_csv(cur, input_data, input_table, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults=None):
+def _load_input_data_csv(cur, input_data, input_tnames, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults=None):
     if use_defaults is None:
         use_defaults = set()
 
     hdr = next(csv.reader([ input_data.readline().decode() ]))
 
-    inputcol_names = set(
-        [ mkcol_aliases.get(c, c.name) for c in mkcols ]
-        + [ nmkcol_aliases.get(c, c.name) for c in nmkcols ]
-    )
-    csvcol_names = set()
+    inputcol_names = {
+        mkcol_aliases.get(c, c.name): c
+        for c in mkcols
+    }
+    inputcol_names |= {
+        nmkcol_aliases.get(c, c.name): c
+        for c in nmkcols
+    }
+    csvcol_names = {}
     csvcol_names_ordered = []
     for cn in hdr:
         try:
-            inputcol_names.remove(cn)
-            csvcol_names.add(cn)
+            csvcol_names[cn] = inputcol_names.pop(cn)
             csvcol_names_ordered.append(cn)
         except KeyError:
             if cn in csvcol_names:
@@ -440,7 +475,7 @@ def _load_input_data_csv(cur, input_data, input_table, mkcols, nmkcols, mkcol_al
             else:
                 raise ConflictModel('CSV column %s not recognized.' % cn)
 
-    inputcol_names = set(inputcol_names).difference(set([ c.name for c in use_defaults ]))
+    inputcol_names = set(inputcol_names.keys()).difference(set([ c.name for c in use_defaults ]))
     if inputcol_names:
         raise BadData('Missing expected CSV column%s: %s.' % (
             ('' if len(inputcol_names) == 0 else 's'),
@@ -448,6 +483,7 @@ def _load_input_data_csv(cur, input_data, input_table, mkcols, nmkcols, mkcol_al
         ))
 
     try:
+        # store input CSV, keeping array cols as text
         cur.copy_expert(u"""
 COPY %(input_table)s (%(cols)s)
 FROM STDIN WITH (
@@ -456,15 +492,58 @@ FROM STDIN WITH (
     DELIMITER ',',
     QUOTE '"'
 )""" % {
-    'input_table': sql_identifier(input_table),
+    'input_table': sql_identifier(input_tnames["csv"]),
     'cols': ','.join([ sql_identifier(cn) for cn in csvcol_names_ordered ])
 },
             input_data
         )
+
+        # transfer to real input table, rewriting array cols
+        def col_select(cn):
+            c = csvcol_names[cn]
+            if not c.type.is_array:
+                return sql_identifier(cn)
+            elif c.type.name in {'json[]','jsonb[]'}:
+                return ("""CASE
+WHEN %(cn)s IS NULL THEN NULL::%(ctype)s
+WHEN SUBSTRING(%(cn)s FROM 1 FOR 1) = '{' THEN %(cn)s::%(ctype)s
+ELSE (
+  SELECT array_agg(v)::%(ctype)s
+  FROM json_array_elements(%(cn)s::json) j(v)
+)
+END
+""" % {
+    "cn": sql_identifier(cn),
+    "ctype": c.type.sql(basic_storage=True),
+})
+            else:
+                return ("""CASE
+WHEN %(cn)s IS NULL THEN NULL::%(ctype)s
+WHEN SUBSTRING(%(cn)s FROM 1 FOR 1) = '{' THEN %(cn)s::%(ctype)s
+ELSE (
+  SELECT array_agg(v)::%(ctype)s
+  FROM json_array_elements_text(%(cn)s::json) j(v)
+)
+END
+""" % {
+    "cn": sql_identifier(cn),
+    "ctype": c.type.sql(basic_storage=True),
+})
+
+        cur.execute(u"""
+INSERT INTO %(input_table)s (%(targets)s)
+SELECT %(selects)s FROM %(input_csv_table)s
+""" % {
+    "input_table": sql_identifier(input_tnames["data"]),
+    "input_csv_table": sql_identifier(input_tnames["csv"]),
+    "targets": ",".join([ sql_identifier(cn) for cn in csvcol_names_ordered ]),
+    "selects": ",".join([ col_select(cn) for cn in csvcol_names_ordered ]),
+})
     except psycopg2.DataError as e:
         raise BadData(u'Bad CSV input. ' + e.pgerror)
 
-def _load_input_data_json(cur, input_data, input_table, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults=None):
+
+def _load_input_data_json(cur, input_data, input_tnames, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults=None):
     if use_defaults is None:
         use_defaults = set()
 
@@ -484,7 +563,7 @@ FROM (
     AS rs ( j )
 ) s
 """ % {
-    'input_table': sql_identifier(input_table),
+    'input_table': sql_identifier(input_tnames["data"]),
     'cols': u','.join(json_cols),
     'input': text_type.sql_literal(buf),
     'json_projection': ','.join(json_projection)
@@ -493,13 +572,13 @@ FROM (
     except psycopg2.DataError as e:
         raise BadData('Bad JSON array input. ' + e.pgerror)
 
-def _load_input_data_json_stream(cur, input_data, input_table, input_json_table, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults=None):
+def _load_input_data_json_stream(cur, input_data, input_tnames, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults=None):
     json_cols, json_projection = _build_json_projections(
         mkcols, nmkcols,
         mkcol_aliases, nmkcol_aliases
     )
     try:
-        cur.copy_expert( "COPY %s (j) FROM STDIN" % sql_identifier(input_json_table), input_data )
+        cur.copy_expert( "COPY %s (j) FROM STDIN" % sql_identifier(input_tnames["json"]), input_data )
         _set_statement_timeout(cur)
         cur.execute(u"""
 INSERT INTO %(input_table)s (%(cols)s)
@@ -509,8 +588,8 @@ FROM (
   FROM %(input_json)s i
 ) s
 """ % {
-    'input_table': sql_identifier(input_table),
-    'input_json': sql_identifier(input_json_table),
+    'input_table': sql_identifier(input_tnames["data"]),
+    'input_json': sql_identifier(input_tnames["json"]),
     'cols': ','.join(json_cols),
     'json_projection': ','.join(json_projection),
 }
@@ -518,13 +597,13 @@ FROM (
     except psycopg2.DataError as e:
         raise BadData('Bad JSON stream input. ' + e.pgerror)
 
-def _load_input_data(cur, input_data, input_table, input_json_table, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, in_content_type, use_defaults=None):
+def _load_input_data(cur, input_data, input_tnames, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, in_content_type, use_defaults=None):
     if in_content_type == 'text/csv':
-        _load_input_data_csv(cur, input_data, input_table, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults)
+        _load_input_data_csv(cur, input_data, input_tnames, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults)
     elif in_content_type == 'application/json':
-        _load_input_data_json(cur, input_data, input_table, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults)
+        _load_input_data_json(cur, input_data, input_tnames, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults)
     elif in_content_type == 'application/x-json-stream':
-        _load_input_data_json_stream(cur, input_data, input_table, input_json_table, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults)
+        _load_input_data_json_stream(cur, input_data, input_tnames, mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_defaults)
     else:
         raise UnsupportedMediaType('%s input not supported' % in_content_type)
 
@@ -1187,7 +1266,7 @@ class EntityElem (object):
             if cname in self.table.columns
         ])
 
-        input_table, input_json_table = _create_temp_input_tables(
+        input_tnames = _create_temp_input_tables(
             cur,
             mkcols, nmkcols,
             mkcol_aliases, nmkcol_aliases,
@@ -1197,16 +1276,16 @@ class EntityElem (object):
         )
 
         _load_input_data(
-            cur, input_data, input_table, input_json_table,
+            cur, input_data, input_tnames,
             mkcols, nmkcols,
             mkcol_aliases, nmkcol_aliases,
             in_content_type
         )
 
-        _analyze_input_table(cur, input_table, mkcols, mkcol_aliases)
+        _analyze_input_table(cur, input_tnames["data"], mkcols, mkcol_aliases)
 
         will_insert = _enforce_table_upsert_static(
-            cur, self.table, input_table,
+            cur, self.table, input_tnames["data"],
             mkcols, nmkcols,
             mkcol_aliases, nmkcol_aliases
         )
@@ -1216,7 +1295,7 @@ class EntityElem (object):
                 raise ConflictModel('Entity insertion requires at least one non-defaulting column.')
 
         _enforce_table_upsert_dynamic(
-            cur, self.table, input_table,
+            cur, self.table, input_tnames["data"],
             mkcols, nmkcols,
             mkcol_aliases, nmkcol_aliases,
             will_insert,
@@ -1225,7 +1304,7 @@ class EntityElem (object):
 
         try:
             results1, results2 = _perform_table_upsert(
-                cur, self.table, input_table,
+                cur, self.table, input_tnames["data"],
                 mkcols, nmkcols,
                 mkcol_aliases, nmkcol_aliases,
                 content_type,
@@ -1364,7 +1443,7 @@ class EntityElem (object):
         if not set(mkcols).union(set(nmkcols)).difference(use_defaults):
             raise ConflictModel('Entity insertion requires at least one non-defaulting column.')
 
-        input_table, input_json_table = _create_temp_input_tables(
+        input_tnames = _create_temp_input_tables(
             cur,
             mkcols, nmkcols,
             mkcol_aliases, nmkcol_aliases,
@@ -1374,24 +1453,24 @@ class EntityElem (object):
         )
 
         _load_input_data(
-            cur, input_data, input_table, input_json_table,
+            cur, input_data, input_tnames,
             mkcols, nmkcols,
             mkcol_aliases, nmkcol_aliases,
             in_content_type,
             use_defaults
         )
 
-        _analyze_input_table(cur, input_table, mkcols, mkcol_aliases)
+        _analyze_input_table(cur, input_tnames["data"], mkcols, mkcol_aliases)
 
         _enforce_table_insert_static(
-            cur, self.table, input_table,
+            cur, self.table, input_tnames["data"],
             mkcols, nmkcols,
             mkcol_aliases, nmkcol_aliases,
             use_defaults
         )
 
         _enforce_table_insert_dynamic(
-            cur, self.table, input_table,
+            cur, self.table, input_tnames["data"],
             mkcols, nmkcols,
             mkcol_aliases, nmkcol_aliases,
             use_defaults
@@ -1399,7 +1478,7 @@ class EntityElem (object):
 
         try:
             results = _perform_table_insert(
-                cur, self.table, input_table,
+                cur, self.table, input_tnames["data"],
                 mkcols, nmkcols,
                 mkcol_aliases, nmkcol_aliases,
                 content_type,
@@ -1486,7 +1565,7 @@ class EntityElem (object):
         mkcols, nmkcols = attr_update
         mkcol_aliases, nmkcol_aliases = attr_aliases if attr_aliases is not None else (dict(), dict())
 
-        input_table, input_json_table = _create_temp_input_tables(
+        input_tnames = _create_temp_input_tables(
             cur,
             mkcols, nmkcols,
             mkcol_aliases, nmkcol_aliases,
@@ -1495,34 +1574,34 @@ class EntityElem (object):
         )
 
         _load_input_data(
-            cur, input_data, input_table, input_json_table,
+            cur, input_data, input_tnames,
             mkcols, nmkcols,
             mkcol_aliases, nmkcol_aliases,
             in_content_type
         )
 
-        _analyze_input_table(cur, input_table, mkcols, mkcol_aliases)
+        _analyze_input_table(cur, input_tnames["data"], mkcols, mkcol_aliases)
 
         _enforce_table_update_static(
-            cur, self.table, input_table,
+            cur, self.table, input_tnames["data"],
             mkcols, nmkcols,
             mkcol_aliases, nmkcol_aliases
         )
 
-        _enforce_input_exists(cur, input_table, self.table, mkcols, mkcol_aliases)
+        _enforce_input_exists(cur, input_tnames["data"], self.table, mkcols, mkcol_aliases)
 
         # NOTE: we already prefetch the whole result so might as well build incrementally...
         results = []
 
         _enforce_table_update_dynamic(
-            cur, self.table, input_table,
+            cur, self.table, input_tnames["data"],
             mkcols, nmkcols,
             mkcol_aliases, nmkcol_aliases
         )
 
         try:
             results = _perform_table_update(
-                cur, self.table, input_table,
+                cur, self.table, input_tnames["data"],
                 mkcols, nmkcols,
                 mkcol_aliases, nmkcol_aliases,
                 content_type

--- a/ermrest/ermpath/resource.py
+++ b/ermrest/ermpath/resource.py
@@ -411,17 +411,22 @@ def _build_json_projections(mkcols, nmkcols, mkcol_aliases, nmkcol_aliases, use_
             # extract field as JSON and transform to array
             # since PostgreSQL json_to_recordset fails for native array extraction...
             # if ELSE clause hits a non-array, we'll have a 400 Bad Request error as before
+            if c.type.base_type.sql(basic_storage=True) in {'json','jsonb'}:
+                json_expand = 'json_array_elements'
+            else:
+                json_expand = 'json_array_elements_text'
             json_proj = """
 (CASE
  WHEN json_typeof(j->%(field)s) = 'null'
    THEN NULL::%(type)s[]
  ELSE
-   COALESCE((SELECT array_agg(x::%(type)s) FROM json_array_elements_text(j->%(field)s) s (x)), ARRAY[]::%(type)s[])
+   COALESCE((SELECT array_agg(x::%(type)s) FROM %(json_expand)s(j->%(field)s) s (x)), ARRAY[]::%(type)s[])
  END) AS %(alias)s
 """ % {
     'type': c.type.base_type.sql(basic_storage=True),
     'field': sql_literal(col_name),
     'alias': c.sql_name(col_name),
+    'json_expand': json_expand,
 }
         elif sql_type in ['json', 'jsonb']:
             json_proj = "(j->%s)::%s AS %s" % (
@@ -639,6 +644,18 @@ def preserialize(sql, content_type):
     else:
         raise NotImplementedError('content_type %s' % content_type)
     return sql
+
+def serialize(cur, sql, content_type, output_file):
+    if content_type == 'text/csv':
+        sql = "COPY (%s) TO STDOUT CSV DELIMITER ',' HEADER" % sql
+    elif content_type == 'application/json':
+        # need to avoid JSON pretty-printing that would put newlines which then get escaped by COPY
+        sql = "COPY (WITH q as (%s) SELECT COALESCE(array_to_json(array_agg(row_to_json(q.*)), false)::text, '[]') FROM q) TO STDOUT" % sql
+    elif content_type == 'application/x-json-stream':
+        sql = "COPY (WITH q as (%s) SELECT row_to_json(q.*)::text FROM q) TO STDOUT" % sql
+    else:
+        raise NotImplementedError('serialized content_type %s with output_file.write()' % content_type)
+    cur.copy_expert(sql, output_file)
 
 def _analyze_input_table(cur, input_table, mkcols, mkcol_aliases):
     """Index and analyze input_table ensuring mkcols uniqueness."""
@@ -1741,33 +1758,12 @@ class AnyPath (object):
 
         if output_file:
             # efficiently send results to file
-            if content_type == 'text/csv':
-                sql = "COPY (%s) TO STDOUT CSV DELIMITER ',' HEADER" % sql
-            elif content_type == 'application/json':
-                sql = "COPY (SELECT array_to_json(array_agg(row_to_json(q.*)), True)::text FROM (%s) q) TO STDOUT" % sql
-            elif content_type == 'application/x-json-stream':
-                sql = "COPY (SELECT row_to_json(q.*)::text FROM (%s) q) TO STDOUT" % sql
-            else:
-                raise NotImplementedError('content_type %s with output_file.write()' % content_type)
-
             _set_statement_timeout(cur)
-            cur.copy_expert(sql, output_file)
-
+            serialize(cur, sql, content_type, output_file)
             return output_file
         else:
             # generate rows to caller
-            if content_type == 'text/csv':
-                # TODO implement and use row_to_csv() stored procedure?
-                pass
-            elif content_type == 'application/json':
-                sql = "SELECT array_to_json(COALESCE(array_agg(row_to_json(q.*)), ARRAY[]::json[]), True)::text FROM (%s) q" % sql
-            elif content_type == 'application/x-json-stream':
-                sql = "SELECT row_to_json(q.*)::text FROM (%s) q" % sql
-            elif content_type in [ dict, tuple ]:
-                pass
-            else:
-                raise NotImplementedError('content_type %s' % content_type)
-
+            sql = preserialize(sql, content_type)
             #deriva_debug(sql)
             _set_statement_timeout(cur)
             cur.execute(sql)

--- a/ermrest/ermpath/resource.py
+++ b/ermrest/ermpath/resource.py
@@ -33,7 +33,7 @@ from psycopg2._json import JSON_OID, JSONB_OID
 
 from ..exception import *
 from ..util import sql_identifier, sql_literal, random_name
-from ..model.type import text_type, aggfuncs
+from ..model.type import text_type, json_type, aggfuncs
 from ..model import predicate
 
 class _FakeEntityElem (object):
@@ -1620,7 +1620,7 @@ class AnyPath (object):
     """Hierarchical ERM access to resources, a generic parent-class for concrete resources.
 
     """
-    def sql_get(self, row_content_type='application/json', limit=None, prefix='', enforce_client=True):
+    def sql_get(self, row_content_type='application/json', limit=None, prefix='', enforce_client=True, arrays_to_json=False):
         """Generate SQL query to get the resources described by this path.
 
            The query will be of the form:
@@ -1702,7 +1702,7 @@ class AnyPath (object):
 
         return aggregates, extras, output_type_overrides
 
-    def get(self, conn, cur, content_type='text/csv', output_file=None, limit=None):
+    def get(self, conn, cur, content_type='text/csv', output_file=None, limit=None, arrays_to_json=False):
         """Fetch resources.
 
            conn: sanepg2 database connection to catalog
@@ -1735,7 +1735,7 @@ class AnyPath (object):
         elif hasattr(self, 'epath'):
             self.epath._path[0].table.enforce_right('select')
 
-        sql = self.sql_get(row_content_type=content_type, limit=limit, dynauthz=True)
+        sql = self.sql_get(row_content_type=content_type, limit=limit, dynauthz=True, arrays_to_json=arrays_to_json)
 
         #deriva_debug(sql)
 
@@ -1754,7 +1754,6 @@ class AnyPath (object):
             cur.copy_expert(sql, output_file)
 
             return output_file
-
         else:
             # generate rows to caller
             if content_type == 'text/csv':
@@ -1772,7 +1771,6 @@ class AnyPath (object):
             #deriva_debug(sql)
             _set_statement_timeout(cur)
             cur.execute(sql)
-            
             return make_row_thunk(None, cur, content_type)()
 
 class EntityPath (AnyPath):
@@ -1903,7 +1901,7 @@ class EntityPath (AnyPath):
         # select access was already enforced for enumerable output columns
         return (key.keyname, key.descending, column.type)
 
-    def sql_get(self, selects=None, distinct_on=True, row_content_type='application/json', limit=None, dynauthz=None, access_type='select', prefix='', enforce_client=True, dynauthz_testcol=None):
+    def sql_get(self, selects=None, distinct_on=True, row_content_type='application/json', limit=None, dynauthz=None, access_type='select', prefix='', enforce_client=True, dynauthz_testcol=None, arrays_to_json=False):
         """Generate SQL query to get the entities described by this epath.
 
            The query will be of the form:
@@ -1927,10 +1925,15 @@ class EntityPath (AnyPath):
             if enforce_client:
                 for col in context_table.columns_in_order(enforce_client=enforce_client):
                     col.enforce_data_right('select')
-            selects = ", ".join([
-                "%st%d.%s" % (prefix, context_pos, sql_identifier(col.name))
-                for col in context_table.columns_in_order()
-            ])
+
+            selects = []
+            for col in context_table.columns_in_order():
+                sql = "%st%d.%s" % (prefix, context_pos, sql_identifier(col.name))
+                if arrays_to_json and col.type.is_array:
+                    sql = 'array_to_json(%s) as %s' % (sql, sql_identifier(col.name))
+                selects.append(sql)
+
+            selects = ','.join(selects)
 
         if dynauthz_testcol is not None:
             assert context_table.columns[dynauthz_testcol.name] == dynauthz_testcol
@@ -2260,7 +2263,7 @@ class AttributePath (AnyPath):
             raise BadData('Sort key "%s" not among output columns.' % key.keyname)
         return (key.keyname, key.descending, self.output_types[key.keyname])
 
-    def sql_get(self, split_sort=False, distinct_on=True, row_content_type='application/json', limit=None, dynauthz=None, access_type='select', prefix='', enforce_client=True):
+    def sql_get(self, split_sort=False, distinct_on=True, row_content_type='application/json', limit=None, dynauthz=None, access_type='select', prefix='', enforce_client=True, arrays_to_json=False):
         """Generate SQL query to get the resources described by this apath.
 
            The query will be of the form:
@@ -2391,8 +2394,6 @@ END
             else:
                 select = "%s.%s" % (alias, col.sql_name())
 
-            select = select
-
             if enforce_client \
                and col is not None \
                and not hasattr(attribute, 'aggfunc'):
@@ -2408,14 +2409,22 @@ END
                 if str(attribute.alias) in outputs:
                     raise BadSyntax('Output column name "%s" appears more than once.' % attribute.alias)
                 outputs.add(str(attribute.alias))
-                output_types[str(attribute.alias)] = col.type
-                selects.append('%s AS %s' % (select, sql_identifier(attribute.alias)))
+                if arrays_to_json:
+                    output_types[str(attribute.alias)] = json_type
+                    selects.append('array_to_json(%s) AS %s' % (select, sql_identifier(attribute.alias)))
+                else:
+                    output_types[str(attribute.alias)] = col.type
+                    selects.append('%s AS %s' % (select, sql_identifier(attribute.alias)))
             else:
                 if col.name in outputs:
                     raise BadSyntax('Output column name "%s" appears more than once.' % col.name)
                 outputs.add(col.name)
-                output_types[col.name] = col.type
-                selects.append('%s AS %s' % (select, col.sql_name()))
+                if arrays_to_json and col.type.is_array:
+                    output_types[col.name] = json_type
+                    selects.append('array_to_json(%s) AS %s' % (select, col.sql_name()))
+                else:
+                    output_types[col.name] = col.type
+                    selects.append('%s AS %s' % (select, col.sql_name()))
 
         # HACK: _get_sortvec() calls _get_sort_element() which looks at self.outputs and self.output_types
         self.outputs = outputs
@@ -2431,9 +2440,9 @@ END
 
         if split_sort:
             # let the caller compose the query and the sort clauses
-            return (self.epath.sql_get(selects=selects, distinct_on=distinct_on, dynauthz=dynauthz, access_type=access_type, prefix=prefix, enforce_client=enforce_client), page, sort1, limit, sort2)
+            return (self.epath.sql_get(selects=selects, distinct_on=distinct_on, dynauthz=dynauthz, access_type=access_type, prefix=prefix, enforce_client=enforce_client, arrays_to_json=arrays_to_json), page, sort1, limit, sort2)
         else:
-            sql = self.epath.sql_get(selects=selects, distinct_on=distinct_on, dynauthz=dynauthz, access_type=access_type, prefix=prefix, enforce_client=enforce_client)
+            sql = self.epath.sql_get(selects=selects, distinct_on=distinct_on, dynauthz=dynauthz, access_type=access_type, prefix=prefix, enforce_client=enforce_client, arrays_to_json=arrays_to_json)
                 
             if sort1 is not None:
                 sql = "SELECT * FROM (%s) s %s ORDER BY %s %s" % (sql, page, sort1, limit)
@@ -2567,7 +2576,7 @@ class AttributeGroupPath (AnyPath):
             raise BadData('Sort key "%s" not among output columns.' % key.keyname)
         return (key.keyname, key.descending, otype)
 
-    def sql_get(self, row_content_type='application/json', limit=None, dynauthz=None, access_type='select', prefix='', enforce_client=True):
+    def sql_get(self, row_content_type='application/json', limit=None, dynauthz=None, access_type='select', prefix='', enforce_client=True, arrays_to_json=False):
         """Generate SQL query to get the resources described by this apath.
 
            The query will be of the form:
@@ -2590,7 +2599,7 @@ class AttributeGroupPath (AnyPath):
         self.apath = apath
         apath.add_sort(self.sort)
         apath.add_paging(self.after, self.before)
-        
+
         groupkeys = []
         aggregates = []
         extras = [] # deprecated
@@ -2604,12 +2613,33 @@ class AttributeGroupPath (AnyPath):
         asql, page, sort1, limit, sort2 = apath.sql_get(split_sort=True, distinct_on=False, limit=limit, dynauthz=dynauthz, access_type=access_type, prefix=prefix, enforce_client=enforce_client)
         aggregates, extras, self.output_type_overrides = self._sql_get_agg_attributes()
 
+        # HACK: allow lookup below by quoted aggregate identifier...
+        attr_type_overrides = {
+            sql_identifier(n): t
+            for n, t in self.output_type_overrides.items()
+        }
+
         if extras:
             raise NotImplementedError('found unexpected extras in aggregation')
             # an impure aggregate query finds exemplars via custom coalesce_agg() 
             # which is folded into the core aggregate query, so extras should ALWAYS be empty now
         else:
-            # a pure aggregate query has only group keys and aggregates
+            # a pure aggregate query has only group keys and aggregates as projection
+            groupaggs = []
+
+            for key, col, base in self.groupkeys:
+                gk = sql_identifier(str(key.alias)) if key.alias is not None else sql_identifier(col.name)
+                if arrays_to_json and col.type.is_array:
+                    gk = 'array_to_json(%s) AS %s' % (gk, gk)
+                groupaggs.append(gk)
+
+            for sql, attr in aggregates:
+                if arrays_to_json and attr_type_overrides.get(attr, text_type).is_array:
+                    ga = 'array_to_json(%s) AS %s' % (sql, attr)
+                else:
+                    ga = '%s AS %s' % (sql, attr)
+                groupaggs.append(ga)
+
             sql = """
 SELECT %(groupaggs)s
 FROM ( %(asql)s ) s
@@ -2618,7 +2648,7 @@ GROUP BY %(groupkeys)s
         sql = sql % dict(
             asql=asql,
             groupkeys=', '.join(groupkeys),
-            groupaggs=', '.join(groupkeys + ["%s AS %s" % a for a in aggregates]),
+            groupaggs=', '.join(groupaggs),
             )
 
         if sort1 is not None:
@@ -2743,7 +2773,7 @@ class AggregatePath (AnyPath):
         # to honour generic API.  actually gated on self.add_sort() above so no need to test again
         pass
         
-    def sql_get(self, row_content_type='application/json', limit=None, dynauthz=None, prefix='', enforce_client=True):
+    def sql_get(self, row_content_type='application/json', limit=None, dynauthz=None, prefix='', enforce_client=True, arrays_to_json=False):
         """Generate SQL query to get the resources described by this apath.
 
         """
@@ -2751,14 +2781,28 @@ class AggregatePath (AnyPath):
         aggregates, extras, output_type_overrides = self._sql_get_agg_attributes(allow_extra=False)
         asql, page, sort1, limit, sort2 = apath.sql_get(split_sort=True, distinct_on=False, dynauthz=dynauthz, prefix=prefix, enforce_client=enforce_client)
 
+        # HACK: allow lookup below by quoted aggregate identifier
+        attr_type_overrides = {
+            sql_identifier(n): t
+            for n, t in output_type_overrides.items()
+        }
+
         # a pure aggregate query has aggregates
+        aggs = []
+        for sql, attr in aggregates:
+            if arrays_to_json and attr_type_overrides.get(attr, text_type).is_array:
+                agg = 'array_to_json(%s) AS %s' % (sql, attr)
+            else:
+                agg = '%s AS %s' % (sql, attr)
+            aggs.append(agg)
+
         sql = """
 SELECT %(aggs)s
 FROM ( %(asql)s ) s
 """
         return sql % dict(
             asql=asql,
-            aggs=', '.join([ '%s AS %s' % (a[0], a[1]) for a in aggregates]),
+            aggs=', '.join(aggs),
             )
 
 class QueryPath (object):
@@ -2850,7 +2894,7 @@ class TextFacet (AnyPath):
                             if c_policy:
                                 yield (sname, tname, column)
 
-    def sql_get(self, row_content_type='application/json', limit=None, dynauthz=None, prefix='', enforce_client=True):
+    def sql_get(self, row_content_type='application/json', limit=None, dynauthz=None, prefix='', enforce_client=True, arrays_to_json=False):
         queries = [
             # column ~* pattern is ciregexp...
             """(SELECT %(stext)s::text AS "schema", %(ttext)s::text AS "table", %(ctext)s::text AS "column" FROM %(sid)s.%(tid)s WHERE _ermrest.astext(%(cid)s) ~* %(pattern)s LIMIT 1)""" % dict(

--- a/ermrest/ermpath/resource.py
+++ b/ermrest/ermpath/resource.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2023 University of Southern California
+# Copyright 2013-2026 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ermrest/model/type.py
+++ b/ermrest/model/type.py
@@ -373,6 +373,7 @@ text_type = mock_type({'typename': 'text', 'length': -1}, readonly=True)
 tsvector_type = mock_type({'typename': 'tsvector', 'length': -1}, readonly=True)
 int8_type = mock_type({'typename': 'int8', 'length': -1}, readonly=True)
 float8_type = mock_type({'typename': 'float8', 'length': -1}, readonly=True)
+json_type = mock_type({'typename': 'json', 'length': -1}, readonly=True)
 jsonb_type = mock_type({'typename': 'jsonb', 'length': -1}, readonly=True)
 
 class AggFunc(object):
@@ -433,6 +434,7 @@ class AggMin(AggFunc):
         }:
             raise exception.ConflictModel('Aggregate function "%s" not allowed on column %s with type %s.' % (self.aggfunc, col.name, col.type.name))
         AggFunc.__init__(self, attribute, col, sql_attr)
+        self.output_type = col.type
 
 class AggMax(AggMin):
     aggfunc = 'max'

--- a/ermrest/model/type.py
+++ b/ermrest/model/type.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2023 University of Southern California
+# Copyright 2013-2026 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ermrest/url/ast/data/__init__.py
+++ b/ermrest/url/ast/data/__init__.py
@@ -79,9 +79,11 @@ def _GET(handler, uri, dresource, vresource):
 
     if content_type == 'text/csv':
         results = tempfile.TemporaryFile()
+        arrays_to_json = handler.queryopts.get('arrays') == 'json'
     else:
         results = None
-        
+        arrays_to_json = False
+
     def body(conn, cur):
         try:
             conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_REPEATABLE_READ)
@@ -89,7 +91,7 @@ def _GET(handler, uri, dresource, vresource):
             handler.http_check_preconditions()
             dresource.add_sort(handler.sort)
             dresource.add_paging(handler.after, handler.before)
-            return dresource.get(conn, cur, content_type=content_type, output_file=results, limit=limit)
+            return dresource.get(conn, cur, content_type=content_type, output_file=results, limit=limit, arrays_to_json=arrays_to_json)
         finally:
             try:
                 conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_SERIALIZABLE)

--- a/ermrest/url/ast/data/__init__.py
+++ b/ermrest/url/ast/data/__init__.py
@@ -1,6 +1,6 @@
 
 # 
-# Copyright 2013-2023 University of Southern California
+# Copyright 2013-2026 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -150,6 +150,7 @@ def service_features():
         "quantified_rid_lists": True,
         "rid_lease": True,
         "registry_catalog": True,
+        "csv_array_json": True,
     }
 
 class OrderedFrozenSet (collections.abc.Set):

--- a/ermrest/util.py
+++ b/ermrest/util.py
@@ -1,5 +1,6 @@
+
 # 
-# Copyright 2012-2024 University of Southern California
+# Copyright 2012-2026 University of Southern California
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/resttest/ctypes_test.py
+++ b/test/resttest/ctypes_test.py
@@ -272,7 +272,17 @@ class CtypeText (common.ErmrestTest):
             ),
             200
         )
-        self.assertHttp(self.session.put(self._entity_url(), json=self._data()), 200)
+        self.assertHttp(self.session.delete(self._entity_url()), 204)
+        self.assertHttp(
+            self.session.post(
+                self._entity_url(),
+                data=common.array_to_csv(self._data(), json_array=True),
+                headers={"content-type": "text/csv"}
+            ),
+            200
+        )
+        self.assertHttp(self.session.delete(self._entity_url()), 204)
+        self.assertHttp(self.session.post(self._entity_url(), json=self._data()), 200)
 
     def _pattern_check(self, colname, expected_count, op=None, rval=None):
         r = self.session.get(self._pattern_url(colname, op=op, rval=rval))

--- a/test/resttest/data.py
+++ b/test/resttest/data.py
@@ -128,14 +128,33 @@ class BasicKey (common.ErmrestTest):
         test_quant("a_text::ciregexp::any(foo,bar)", {1,2,3})
         test_quant("*::ciregexp::any(foo,bar)", {1,2,3})
 
-    def test_download(self):
+    def test_qp_download(self):
         r = self.session.get('entity/%s:%s?download=%s' % (_S, self.table, self.table))
         self.assertHttp(r, 200)
         self.assertRegex(
             r.headers.get('content-disposition'),
             "attachment; filename[*]=UTF-8''%s.*" % self.table
         )
-        
+
+    def test_qp_array_to_json(self):
+        for url in [
+                # these check for raw projection of array column values
+                'entity/%s:%s' % (_S, self.table),
+                'attribute/%s:%s/a_int4' % (_S, self.table),
+                'attributegroup/%s:%s/a_int4' % (_S, self.table),
+                # min()/max() pass through source values rather than building JSON
+                'aggregate/%s:%s/x:=max(a_int4)' % (_S, self.table),
+        ]:
+            # first check backwards compat postgresql arrays are produced
+            r = self.session.get(url, headers={"accept": "text/csv"})
+            self.assertHttp(r, 200)
+            self.assertRegex(r.text, '"{0,3}"')
+
+            # then check optional JSON arrays are produced
+            r = self.session.get('%s?arrays=json' % url, headers={"accept": "text/csv"})
+            self.assertHttp(r, 200)
+            self.assertRegex(r.text, '"\\[0,3\\]"')
+
 class CompositeKey (BasicKey):
     table = _Tc1
 


### PR DESCRIPTION
Previously, the service exposes PostgreSQL native array serialization in CSV representations of array-typed columns.

1. Add auto-detection of JSON versus PostgreSQL array syntax when parsing input CSV content in mutation requests.
2. Add arrays=json query parameter to enable JSON array representation in output CSV content in query requests.