### PR TITLE
Fix ALTER SEQUENCE failure on PostgreSQL 16 for identity sequences

### DIFF
--- a/ermrest/sql/change_owner.sql
+++ b/ermrest/sql/change_owner.sql
@@ -55,6 +55,15 @@ BEGIN
     IN SELECT sequence_name
     FROM information_schema.sequences
     WHERE sequence_schema = srow.nspname
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_depend d ON d.objid = c.oid
+        WHERE c.relkind = 'S'
+          AND c.relname = sequence_name
+          AND c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = srow.nspname)
+          AND d.deptype = 'i'
+          AND current_setting('server_version_num')::integer >= 160000
+      )
     LOOP
       EXECUTE 'ALTER SEQUENCE ' || quote_ident(srow.nspname) || '.' || quote_ident(seqrow.sequence_name) || ' OWNER TO ermrest;';
     END LOOP;


### PR DESCRIPTION
  On PG 16+, ALTER SEQUENCE ... OWNER TO raises an error for sequences
  linked to identity columns (GENERATED AS IDENTITY), because PG 16 now
  manages identity sequence ownership automatically when the owning table's
  owner changes. On PG < 16 this was permitted (and necessary, since table
  re-ownership did not cascade to identity sequences).

  Exclude identity sequences (pg_depend.deptype = 'i') from the explicit
  ALTER SEQUENCE loop in change_owner.sql when running on PG 16+. On older
  versions the filter does not apply and ownership is still set explicitly.