### PR TITLE
rationalize two different loops that mean to exclude temporary schemas

### DIFF
--- a/ermrest/sql/change_owner.sql
+++ b/ermrest/sql/change_owner.sql
@@ -29,7 +29,7 @@ BEGIN
   IN SELECT nspname
      FROM pg_namespace
      WHERE nspname NOT IN ('pg_toast', 'pg_catalog', 'information_schema')
-       AND NOT pg_is_other_temp_schema(oid)
+       AND nspname !~ '^pg_(toast_)?temp_'
   LOOP
     EXECUTE 'ALTER SCHEMA ' || quote_ident(srow.nspname) || ' OWNER TO ermrest;';
 

--- a/ermrest/sql/ermrest_schema.sql
+++ b/ermrest/sql/ermrest_schema.sql
@@ -856,7 +856,6 @@ CREATE OR REPLACE VIEW _ermrest.introspect_schemas AS
   FROM pg_catalog.pg_namespace nc
   WHERE nc.nspname NOT IN ('information_schema', 'pg_toast', '_ermrest_history')
     AND nc.nspname !~ '^pg_(toast_)?temp_'
-    AND NOT pg_is_other_temp_schema(nc.oid)
 ;
 
 CREATE OR REPLACE VIEW _ermrest.introspect_types AS


### PR DESCRIPTION
We want to exclude ALL temporary schemas, not just "other" temporary schemas during introspection and redeployment tasks.

So just use the more general regexp match we already have in the introspection scenario:

    WHERE ... nc.nspname !~ '^pg_(toast_)?temp_'

and stop using the pg_is_other_temp_schema() function at all.